### PR TITLE
v0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,6 @@ The Intention is for this app to become available on Windows, Linux, Mac, Androi
 
 ## ToDo
 
-- [ ] Handle situation where there's no audio in a feed
 - [ ] Additional Downloads Page organization - Organize by Podcast
 - [ ] Download entire podcast button. For episode archival
 - [ ] Restore Server via GUI

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The Intention is for this app to become available on Windows, Linux, Mac, Androi
 - [ ] Ensure descriptions appear when searching itunes podcasts. This will take some very fast external parsing.
 - [ ] Guest User
 - [ ] Installable PWA
+- [ ] Add Fyyd as searching index
 - [ ] Jump to clicked timestamp
 - [ ] Timestamps in playing page
 - [ ] Offline mode for playing locally downloaded episodes

--- a/clients/clientapi.py
+++ b/clients/clientapi.py
@@ -545,6 +545,31 @@ async def api_podcast_id(cnx=Depends(get_database_connection),
         raise HTTPException(status_code=403,
                             detail="You can only return pocast ids of your own podcasts!")
 
+@app.get("/api/data/get_podcast_details")
+async def api_podcast_id(podcast_id: str = Query(...), cnx=Depends(get_database_connection),
+                              api_key: str = Depends(get_api_key_from_header),
+                              user_id: int = Query(...)):
+    is_valid_key = database_functions.functions.verify_api_key(cnx, api_key)
+    if not is_valid_key:
+        raise HTTPException(status_code=403,
+                            detail="Your API key is either invalid or does not have correct permission")
+
+    # Check if the provided API key is the web key
+    is_web_key = api_key == base_webkey.web_key
+
+    key_id = database_functions.functions.id_from_api_key(cnx, api_key)
+
+    # Allow the action if the API key belongs to the user, or it's the web API key
+    if key_id == user_id or is_web_key:
+        details = database_functions.functions.get_podcast_details(database_type, cnx, user_id, podcast_id)
+        if details is None:
+            episodes = []  # Return an empty list instead of raising an exception
+        return {"details": details}
+    else:
+        raise HTTPException(status_code=403,
+                            detail="You can only return pocast ids of your own podcasts!")
+
+
 class PodcastFeedData(BaseModel):
     podcast_feed: str
 
@@ -2571,11 +2596,55 @@ def refresh_nextcloud_subscription_for_user(database_type, user_id, gpodder_url,
         else:
             cnx.close()
 
+def check_valid_feed(feed_url: str):
+    import feedparser
+    parsed_feed = feedparser.parse(feed_url)
+    if not parsed_feed.get('version'):
+        raise ValueError("Invalid podcast feed URL or content.")
+    if not ('title' in parsed_feed.feed and 'link' in parsed_feed.feed and 'description' in parsed_feed.feed):
+        raise ValueError("Feed missing required attributes: title, link, or description.")
+    return parsed_feed
+
+class CustomPodcast(BaseModel):
+    feed_url: str
+    user_id: int
+
+@app.post("/api/data/add_custom_podcast")
+async def queue_bump(data: CustomPodcast, cnx=Depends(get_database_connection),
+                     api_key: str = Depends(get_api_key_from_header)):
+    is_valid_key = database_functions.functions.verify_api_key(cnx, api_key)
+    if not is_valid_key:
+        raise HTTPException(status_code=403,
+                            detail="Your API key is either invalid or does not have correct permission")
+
+    # Check if the provided API key is the web key
+    is_web_key = api_key == base_webkey.web_key
+
+    key_id = database_functions.functions.id_from_api_key(cnx, api_key)
+
+    # Allow the action if the API key belongs to the user or it's the web API key
+    if key_id == data.user_id or is_web_key:
+        try:
+            parsed_feed = check_valid_feed(data.feed_url)
+        except ValueError as e:
+            logger.error(f"Failed to parse: {str(e)}")
+            raise HTTPException(status_code=400, detail=str(e))
+
+        # Assuming the rest of the code processes the podcast correctly
+        try:
+            result = database_functions.functions.add_custom_podcast(database_type, cnx, data.feed_url, data.user_id)
+            return {"data": result}
+        except Exception as e:
+            logger.error(f"Failed to process the podcast: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"Failed to process the podcast: {str(e)}")
+    else:
+        raise HTTPException(status_code=403,
+                            detail="You can only add podcasts for yourself!")
+
 class QueueBump(BaseModel):
     ep_url: str
     title: str
     user_id: int
-
 
 @app.post("/api/data/queue_bump")
 async def queue_bump(data: QueueBump, cnx=Depends(get_database_connection),

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -2,6 +2,16 @@
 
 This is the list of previous todos that are now completed
 
+Version 0.6.3
+
+- [] Fix appearance and layout of podcasts on podcast screen or on searching pages.
+- [] Fix mobile experience to make images consistently sized
+- [x] Fixed layout of pinepods logo on user stats screen
+- [x] Expanded the search bar on search podcasts page for small screens. It was being cut off a bit
+- [] Fixed order of history page
+- [x] Downloads page typo
+- [] Improve look of search podcast dropdown on small screens
+
 Version 0.6.2
 
 - [x] Fixed issue with removal of podcasts when no longer in nextcloud subscription

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -15,9 +15,9 @@ Version 0.6.3
 - [x] Added area in the settings to add custom podcast feeds
 - [x] Added a Pinepods news feed that gets automatically subscribed to on fresh installs. You can easily unsubscribe from this if you don't care about it
 - [x] Added ability to access episodes for an entire podcast from the episode display screen (click the podcast name)
+- [x] Created functionality so the app can handle when a feed doesn't contain an audio file
 - [] Added option to podcast pages to allow for downloading every episode
 - [] Fixed issue where spacebar didn't work in app when episode was playing
-- [] Created functionality so the app can handle when a feed doesn't contain an audio file
 - [] Added Postgresql support
 - [] Enhanced downloads page to better display podcasts. This improves archival experience
 - [] Added Better Download support to the client versions.

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -13,11 +13,14 @@ Version 0.6.3
 - [x] Improve look of search podcast dropdown on small screens
 - [x] Made the setting accordion hover effect only over the arrows.
 - [x] Added area in the settings to add custom podcast feeds
-- [] Created functionality so the app can handle when a feed doesn't contain an audio file
-- [] Added a Pinepods news feed that gets automatically subscribed to on fresh installs. You can easily unsubscribe from this if you don't care about it
-- [] Added option to podcast pages to allow for downloading every episode
+- [x] Added a Pinepods news feed that gets automatically subscribed to on fresh installs. You can easily unsubscribe from this if you don't care about it
 - [x] Added ability to access episodes for an entire podcast from the episode display screen (click the podcast name)
+- [] Added option to podcast pages to allow for downloading every episode
 - [] Fixed issue where spacebar didn't work in app when episode was playing
+- [] Created functionality so the app can handle when a feed doesn't contain an audio file
+- [] Added Postgresql support
+- [] Enhanced downloads page to better display podcasts. This improves archival experience
+- [] Added Better Download support to the client versions.
 
 Version 0.6.2
 

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -4,13 +4,20 @@ This is the list of previous todos that are now completed
 
 Version 0.6.3
 
-- [] Fix appearance and layout of podcasts on podcast screen or on searching pages.
-- [] Fix mobile experience to make images consistently sized
+- [x] Fix appearance and layout of podcasts on podcast screen or on searching pages. (Also added additional see more type dropdowns for descriptions to make them fit better.)
+- [x] Fix mobile experience to make images consistently sized
 - [x] Fixed layout of pinepods logo on user stats screen
 - [x] Expanded the search bar on search podcasts page for small screens. It was being cut off a bit
-- [] Fixed order of history page
+- [x] Fixed order of history page
 - [x] Downloads page typo
-- [] Improve look of search podcast dropdown on small screens
+- [x] Improve look of search podcast dropdown on small screens
+- [x] Made the setting accordion hover effect only over the arrows.
+- [x] Added area in the settings to add custom podcast feeds
+- [] Created functionality so the app can handle when a feed doesn't contain an audio file
+- [] Added a Pinepods news feed that gets automatically subscribed to on fresh installs. You can easily unsubscribe from this if you don't care about it
+- [] Added option to podcast pages to allow for downloading every episode
+- [x] Added ability to access episodes for an entire podcast from the episode display screen (click the podcast name)
+- [] Fixed issue where spacebar didn't work in app when episode was playing
 
 Version 0.6.2
 

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -2,6 +2,13 @@
 
 This is the list of previous todos that are now completed
 
+Next edition
+
+- [] Added option to podcast pages to allow for downloading every episode
+- [] Added Postgresql support
+- [] Enhanced downloads page to better display podcasts. This improves archival experience
+- [] Added Better Download support to the client versions.
+
 Version 0.6.3
 
 - [x] Fix appearance and layout of podcasts on podcast screen or on searching pages. (Also added additional see more type dropdowns for descriptions to make them fit better.)
@@ -16,11 +23,12 @@ Version 0.6.3
 - [x] Added a Pinepods news feed that gets automatically subscribed to on fresh installs. You can easily unsubscribe from this if you don't care about it
 - [x] Added ability to access episodes for an entire podcast from the episode display screen (click the podcast name)
 - [x] Created functionality so the app can handle when a feed doesn't contain an audio file
-- [] Added option to podcast pages to allow for downloading every episode
-- [] Fixed issue where spacebar didn't work in app when episode was playing
-- [] Added Postgresql support
-- [] Enhanced downloads page to better display podcasts. This improves archival experience
-- [] Added Better Download support to the client versions.
+- [x] Added playback speed button in the episode playing page. Now you can make playback faster!
+- [x] Added episode skip button in the episode playing page. Skips to the next in the queue.
+- [x] Fixed issue with the reverse button in the episode page so that it now reverses the playback by 15 seconds.
+- [x] Fixed issue where spacebar didn't work in app when episode was playing
+- [x] Added and verified support for mysql databases. Thanks
+- [x] Fixed issue with refreshing on settings page. Thanks 
 
 Version 0.6.2
 

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -27,8 +27,7 @@ Version 0.6.3
 - [x] Added episode skip button in the episode playing page. Skips to the next in the queue.
 - [x] Fixed issue with the reverse button in the episode page so that it now reverses the playback by 15 seconds.
 - [x] Fixed issue where spacebar didn't work in app when episode was playing
-- [x] Added and verified support for mysql databases. Thanks
-- [x] Fixed issue with refreshing on settings page. Thanks 
+- [x] Added and verified support for mysql databases. Thanks @rgarcia6520
 
 Version 0.6.2
 

--- a/database_functions/app_functions.py
+++ b/database_functions/app_functions.py
@@ -149,3 +149,25 @@ def get_podcast_values(feed_url, user_id):
         podcast_values['pod_explicit'] = d.feed.itunes_explicit == 'yes'
 
     return podcast_values
+
+
+
+def check_valid_feed(feed_url: str):
+    import feedparser
+    """
+    Check if the provided URL points to a valid podcast feed.
+    Raises ValueError if the feed is invalid.
+    """
+    parsed_feed = feedparser.parse(feed_url)
+
+    # Check for basic RSS or Atom feed structure
+    if not parsed_feed.get('version'):
+        # If it does not contain a recognizable version, it's likely not a valid feed
+        raise ValueError("Invalid podcast feed URL or content.")
+
+    # Check for essential elements in the feed
+    if not ('title' in parsed_feed.feed and 'link' in parsed_feed.feed and 'description' in parsed_feed.feed):
+        raise ValueError("Feed missing required attributes: title, link, or description.")
+
+    # If it passes the above checks, it's likely a valid feed
+    return parsed_feed

--- a/startup/call_refresh_endpoint.sh
+++ b/startup/call_refresh_endpoint.sh
@@ -11,3 +11,9 @@ echo "Refreshing now!"
 curl "http://localhost:8032/api/data/refresh_pods" -H "Api-Key: $API_KEY" >> /cron.log 2>&1
 echo "Refreshing Nextcloud Subscription now!"
 curl -X GET -H "Api-Key: $API_KEY" http://localhost:8032/api/data/refresh_nextcloud_subscriptions >> /cron.log 2>&1
+
+# Initialize application tasks
+echo "Initializing application tasks..."
+curl -X POST "http://localhost:8032/api/init/startup_tasks" \
+    -H "Content-Type: application/json" \
+    -d "{\"api_key\": \"$API_KEY\"}" >> /cron.log 2>&1

--- a/startup/setupdatabase.py
+++ b/startup/setupdatabase.py
@@ -100,7 +100,8 @@ try:
             AppSettingsID INT AUTO_INCREMENT PRIMARY KEY,
             SelfServiceUser TINYINT(1) DEFAULT 0,
             DownloadEnabled TINYINT(1) DEFAULT 1,
-            EncryptionKey BINARY(44)  -- Set the data type to BINARY(32) to hold the 32-byte key
+            EncryptionKey BINARY(44),  -- Set the data type to BINARY(32) to hold the 32-byte key
+            NewsFeedSubscribed TINYINT(1) DEFAULT 0
         )
     """)
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -45,6 +45,7 @@ futures-util = "0.3.30"
 gloo-file = "0.3.0"
 urlencoding = "2.1.3"
 serde_with = "3.8.1"
+htmlentity = "1.3.1"
 
 [features]
 default = []

--- a/web/src/components/context.rs
+++ b/web/src/components/context.rs
@@ -127,6 +127,7 @@ pub struct UIState {
     pub info_message: Option<String>,
     pub is_expanded: bool,
     pub episode_in_db: Option<bool>,
+    pub playback_speed: f64,
     // pub start_pos_sec: f64,
 }
 

--- a/web/src/components/downloads.rs
+++ b/web/src/components/downloads.rs
@@ -365,7 +365,7 @@ pub fn downloads() -> Html {
                                 let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
     
                                 let on_checkbox_change_cloned = on_checkbox_change.clone();
-
+                                let episode_url_for_ep_item = episode_url_clone.clone();
                                 let item = episode_item(
                                     Box::new(episode),
                                     description.clone(),
@@ -379,6 +379,7 @@ pub fn downloads() -> Html {
                                     "downloads",
                                     on_checkbox_change_cloned, // Add this line
                                     is_delete_mode, // Add this line
+                                    episode_url_for_ep_item
                                 );
 
                                 item

--- a/web/src/components/downloads.rs
+++ b/web/src/components/downloads.rs
@@ -389,7 +389,7 @@ pub fn downloads() -> Html {
                         } else {
                             empty_message(
                                 "No Episode Downloads Found",
-                                "This is where episode downloads will appear. To download an episode you can open the context menu on an episode and select Download Episode. It will then download the the server and show up here!"
+                                "This is where episode downloads will appear. To download an episode you can open the context menu on an episode and select Download Episode. It will then download to the server and show up here!"
                             )
                         }
                     }

--- a/web/src/components/episode.rs
+++ b/web/src/components/episode.rs
@@ -11,10 +11,14 @@ use crate::requests::pod_req::{EpisodeRequest, EpisodeMetadataResponse, QueuePod
 use crate::components::audio::on_play_click;
 use crate::components::episodes_layout::SafeHtml;
 use crate::components::episodes_layout::UIStateMsg;
+use crate::components::click_events::create_on_title_click;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use web_sys::window;
 use crate::requests::login_requests::use_check_authentication;
+use yew_router::history::{BrowserHistory, History};
+use std::collections::HashMap;
+use wasm_bindgen::JsValue;
 
 #[function_component(Episode)]
 pub fn epsiode() -> Html {
@@ -61,6 +65,7 @@ pub fn epsiode() -> Html {
     let server_name = post_state.auth_details.as_ref().map(|ud| ud.server_name.clone());
     let error_message = audio_state.error_message.clone();
     let info_message = audio_state.info_message.clone();
+    let history = BrowserHistory::new();
 
     {
         let ui_dispatch = audio_dispatch.clone();
@@ -137,6 +142,7 @@ pub fn epsiode() -> Html {
                     let episode_title_clone = episode.episode.EpisodeTitle.clone();
                     let episode_artwork_clone = episode.episode.EpisodeArtwork.clone();
                     let episode_duration_clone = episode.episode.EpisodeDuration.clone();
+                    let podcast_of_episode = episode.episode.PodcastID.clone();
                     let episode_listened_clone = Option::from(0);
                     let episode_id_clone = episode.episode.EpisodeID.clone();
     
@@ -276,6 +282,61 @@ pub fn epsiode() -> Html {
                     let date_format = match_date_format(state.date_format.as_deref());
                     let format_duration = format_time(episode.episode.EpisodeDuration as f64);
                     let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
+
+                    let on_title_click = {
+                        let dispatch = dispatch.clone();
+                        let server_name = server_name.clone();
+                        let api_key = api_key.clone();
+                        let podcast_id = podcast_of_episode.clone();
+                        let user_id = user_id.clone();
+                        let history = history.clone();
+                    
+                        Callback::from(move |event: MouseEvent| {
+                            let dispatch = dispatch.clone();
+                            let server_name = server_name.clone();
+                            let api_key = api_key.clone();
+                            let podcast_id = podcast_id.clone();
+                            let user_id = user_id.clone();
+                            let history = history.clone();
+                    
+                            wasm_bindgen_futures::spawn_local(async move {
+                                match pod_req::call_get_podcast_details(&server_name.clone().unwrap(), &api_key.clone().unwrap().unwrap(), user_id.unwrap(), &podcast_id).await {
+                                    Ok(details) => {
+                                        let mut categories_map: HashMap<String, String> = HashMap::new();
+                                        for (index, category) in details.categories.split(',').enumerate() {
+                                            categories_map.insert(index.to_string(), category.trim().to_string());
+                                        }
+                                        // Assuming details contain all necessary podcast info
+                                        let final_click_action = create_on_title_click(
+                                            dispatch.clone(),
+                                            server_name.unwrap(),
+                                            api_key,
+                                            &history,
+                                            details.podcast_name,
+                                            details.feed_url,
+                                            details.description,
+                                            details.author,
+                                            details.artwork_url,
+                                            details.explicit,
+                                            details.episode_count,
+                                            Some(categories_map),
+                                            details.website_url,
+                                            user_id.unwrap(),
+                                        );
+                    
+                                        // Execute the action created by create_on_title_click
+                                        final_click_action.emit(event);
+                                    },
+                                    Err(error) => {
+                                        web_sys::console::log_1(&format!("Error fetching podcast details: {}", error).into());
+                                        dispatch.reduce_mut(move |state| {
+                                            state.error_message = Some(format!("Failed to load details: {}", error));
+                                        });
+                                    }
+                                }
+                            });
+                        })
+                    };
                     
                     // let format_duration = format!("Duration: {} minutes", e / 60); // Assuming duration is in seconds
                     // let format_release = format!("Released on: {}", &episode.episode.EpisodePubDate);
@@ -285,7 +346,7 @@ pub fn epsiode() -> Html {
                             <div class="episode-top-info">
                                 <img src={episode.episode.EpisodeArtwork.clone()} class="episode-artwork" />
                                 <div class="episode-details">
-                                    <h1 class="podcast-title">{ &episode.episode.PodcastName }</h1>
+                                    <h1 class="podcast-title" onclick={on_title_click.clone()}>{ &episode.episode.PodcastName }</h1>
                                     <h2 class="episode-title">{ &episode.episode.EpisodeTitle }</h2>
                                     <p class="episode-duration">{ format_duration }</p>
                                     <p class="episode-release-date">{ format_release }</p>

--- a/web/src/components/episode.rs
+++ b/web/src/components/episode.rs
@@ -337,10 +337,10 @@ pub fn epsiode() -> Html {
                             });
                         })
                     };
-                    
+                    let episode_url_check = episode_url_clone;
+                    let should_show_buttons = !episode_url_check.is_empty();
                     // let format_duration = format!("Duration: {} minutes", e / 60); // Assuming duration is in seconds
                     // let format_release = format!("Released on: {}", &episode.episode.EpisodePubDate);
-    
                     html! {
                         <div class="episode-layout-container">
                             <div class="episode-top-info">
@@ -353,22 +353,36 @@ pub fn epsiode() -> Html {
                                 </div>
                             </div>
                             <div class="episode-action-buttons">
-                                <button onclick={on_play_click} class="play-button">
-                                    <i class="material-icons">{ "play_arrow" }</i>
-                                    {"Play"}
-                                </button>
-                                <button onclick={on_add_to_queue} class="queue-button">
-                                    <i class="material-icons">{ "playlist_add" }</i>
-                                    {"Queue"}
-                                </button>
-                                <button onclick={on_save_episode} class="save-button">
-                                    <i class="material-icons">{ "favorite" }</i>
-                                    {"Save"}
-                                </button>
-                                <button onclick={on_download_episode} class="download-button-ep">
-                                    <i class="material-icons">{ "download" }</i>
-                                    {"Download"}
-                                </button>
+                            {
+                                if should_show_buttons {
+                                    html! {
+                                        <>
+                                        <button onclick={on_play_click} class="play-button">
+                                            <i class="material-icons">{ "play_arrow" }</i>
+                                            {"Play"}
+                                        </button>
+                                        <button onclick={on_add_to_queue} class="queue-button">
+                                            <i class="material-icons">{ "playlist_add" }</i>
+                                            {"Queue"}
+                                        </button>
+                                        <button onclick={on_save_episode} class="save-button">
+                                            <i class="material-icons">{ "favorite" }</i>
+                                            {"Save"}
+                                        </button>
+                                        <button onclick={on_download_episode} class="download-button-ep">
+                                            <i class="material-icons">{ "download" }</i>
+                                            {"Download"}
+                                        </button>
+                                        </>
+                                    }
+                                } else {
+                                    html! {
+                                        <p class="no-media-warning item_container-text play-button">
+                                            {"This item contains no media file"}
+                                        </p>
+                                    }
+                                }
+                            }
                             </div>
                             <hr class="episode-divider" />
                             <div class="episode-single-desc episode-description">

--- a/web/src/components/episodes_layout.rs
+++ b/web/src/components/episodes_layout.rs
@@ -19,7 +19,8 @@ use crate::components::gen_funcs::format_time;
 use crate::requests::login_requests::use_check_authentication;
 use crate::components::gen_funcs::{sanitize_html_with_blank_target, truncate_description, convert_time_to_seconds};
 use wasm_bindgen::prelude::*;
-use htmlentities::decode_html_entities;
+use htmlentity::entity::decode;
+use htmlentity::entity::ICodedDataTrait;
 
 fn add_icon() -> Html {
     html! {
@@ -63,7 +64,14 @@ pub fn safe_html(props: &Props) -> Html {
 
 fn sanitize_html(html: &str) -> String {
     let cleaned_html = ammonia::clean(html);
-    decode_html_entities(&cleaned_html).to_string()
+    let decoded_data = decode(cleaned_html.as_bytes());
+    match decoded_data.to_string() {
+        Ok(decoded_html) => decoded_html,
+        Err(e) => {
+            // web_sys::console::error_1(&e.into());
+            String::from("Invalid HTML content")
+        }
+    }
 }
 
 
@@ -608,12 +616,12 @@ pub fn episode_layout() -> Html {
                                                 // }
                                             }
                                         </div>
-                                        <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8"> // More space on medium and larger screens
+                                        <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8 button-container" style="align-self: center;"> // Add align-self: center; heren medium and larger screens
                                             <button
                                                 class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
                                                 onclick={on_play_click}
                                             >
-                                                <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"play_arrow"}</span>
+                                            <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"play_arrow"}</span>
                                             </button>
                                             {
                                                 if podcast_added {

--- a/web/src/components/episodes_layout.rs
+++ b/web/src/components/episodes_layout.rs
@@ -573,6 +573,8 @@ pub fn episode_layout() -> Html {
                                 let boxed_episode = Box::new(episode.clone()) as Box<dyn EpisodeTrait>;
                                 let duration = episode.duration.clone().unwrap().parse::<f64>().unwrap_or(0.0);
                                 let formatted_duration = format_time(duration);
+                                let episode_url_for_ep_item = episode_url_clone.clone();
+                                let should_show_buttons = !episode_url_for_ep_item.is_empty();
                                 html! {
                                     <div class="item-container flex items-center mb-4 shadow-md rounded-lg">
                                         <img src={episode.artwork.clone().unwrap_or_default()} alt={format!("Cover for {}", &episode.title.clone().unwrap_or_default())} class="object-cover align-top-cover w-full item-container img"/>
@@ -616,29 +618,35 @@ pub fn episode_layout() -> Html {
                                                 // }
                                             }
                                         </div>
-                                        <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8 button-container" style="align-self: center;"> // Add align-self: center; heren medium and larger screens
-                                            <button
-                                                class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
-                                                onclick={on_play_click}
-                                            >
-                                            <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"play_arrow"}</span>
-                                            </button>
-                                            {
-                                                if podcast_added {
-                                                    let page_type = "episode_layout".to_string();
+                                        {
+                                            html! {
+                                                <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8 button-container" style="align-self: center;"> // Add align-self: center; heren medium and larger screens
+                                                    if should_show_buttons {
+                                                        <button
+                                                            class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
+                                                            onclick={on_play_click}
+                                                        >
+                                                        <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"play_arrow"}</span>
+                                                        </button>
+                                                        {
+                                                            if podcast_added {
+                                                                let page_type = "episode_layout".to_string();
 
-                                                    let context_button = html! {
-                                                        <ContextButton episode={boxed_episode} page_type={page_type.clone()} />
-                                                    };
+                                                                let context_button = html! {
+                                                                    <ContextButton episode={boxed_episode} page_type={page_type.clone()} />
+                                                                };
 
 
-                                                    context_button
+                                                                context_button
 
-                                                } else {
-                                                    html! {}
-                                                }
+                                                            } else {
+                                                                html! {}
+                                                            }
+                                                        }
+                                                    }
+                                                </div>
                                             }
-                                        </div>
+                                        }
 
 
                                     </div>

--- a/web/src/components/gen_components.rs
+++ b/web/src/components/gen_components.rs
@@ -278,9 +278,9 @@ pub fn search_bar() -> Html {
                 // Mobile dropdown content
                 if *mobile_dropdown_open {
                     html! {
-                        <div class="search-drop absolute top-full right-0 z-10 divide-y rounded-lg shadow p-4">
+                        <div class="search-drop absolute top-full right-0 z-10 divide-y rounded-lg shadow p-6">
                             // Outline buttons for podcast_index or itunes
-                            <div class="inline-flex rounded-md shadow-sm" role="group">
+                            <div class="inline-flex rounded-md shadow-sm mb-2" role="group">
                                 <button
                                     type="button"
                                     class={format!("px-4 py-2 text-sm font-medium rounded-l-lg search-drop-button {}",
@@ -301,13 +301,13 @@ pub fn search_bar() -> Html {
                             // Text field for search
                             <input
                                 type="text"
-                                class="search-input shorter-input block p-2.5 w-full text-sm rounded-lg border"
+                                class="search-input shorter-input block p-2.5 w-full text-sm rounded-lg mb-2"
                                 placeholder="Search"
                                 value={(*podcast_value).clone()}
                                 oninput={on_input_change.clone()}
                             />
                             // Search button
-                            <button class="search-btn no-margin border border-solid mt-4 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" onclick={on_submit_click.clone()}>
+                            <button class="search-btn border-0 no-margin mt-4 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" onclick={on_submit_click.clone()}>
                                 {"Search"}
                             </button>
                         </div>

--- a/web/src/components/gen_components.rs
+++ b/web/src/components/gen_components.rs
@@ -1002,7 +1002,7 @@ pub fn episode_item(
                         }
                     }
                 </div>
-                <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8" style="align-self: center;"> // Add align-self: center; here
+                <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8 button-container" style="align-self: center;"> // Add align-self: center; here
                     <button
                         class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
                         onclick={on_play_click}

--- a/web/src/components/gen_components.rs
+++ b/web/src/components/gen_components.rs
@@ -915,6 +915,7 @@ pub fn episode_item(
     page_type: &str,
     on_checkbox_change: Callback<i32>,
     is_delete_mode: bool, // Add this line
+    ep_url: String,
 ) -> Html {
     let span_duration = listen_duration.clone();
     let span_episode = episode_duration.clone();
@@ -931,6 +932,7 @@ pub fn episode_item(
         }
     });
     let checkbox_ep = episode.get_episode_id();
+    let should_show_buttons = !ep_url.is_empty();
 
     #[wasm_bindgen]
     extern "C" {
@@ -1002,15 +1004,21 @@ pub fn episode_item(
                         }
                     }
                 </div>
-                <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8 button-container" style="align-self: center;"> // Add align-self: center; here
-                    <button
-                        class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
-                        onclick={on_play_click}
-                    >
-                        <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"play_arrow"}</span>
-                    </button>
-                    <ContextButton episode={episode.clone()} page_type={page_type.to_string()} />
-                </div>
+                {
+                    html! {
+                        <div class="flex flex-col items-center h-full w-2/12 px-2 space-y-4 md:space-y-8 button-container" style="align-self: center;">
+                            if should_show_buttons {
+                                <button
+                                    class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
+                                    onclick={on_play_click}
+                                >
+                                    <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"play_arrow"}</span>
+                                </button>
+                                <ContextButton episode={episode.clone()} page_type={page_type.to_string()} />
+                            }
+                        </div>
+                    }
+                }
                 
                 
                 

--- a/web/src/components/history.rs
+++ b/web/src/components/history.rs
@@ -223,7 +223,7 @@ pub fn history() -> Html {
                                         let date_format = match_date_format(state.date_format.as_deref());
                                         let datetime = parse_date(&episode.EpisodePubDate, &state.user_tz);
                                         let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
-                                        
+                                        let episode_url_for_ep_item = episode_url_clone.clone();
                                         let item = episode_item(
                                             Box::new(episode),
                                             description.clone(),
@@ -237,6 +237,7 @@ pub fn history() -> Html {
                                             "history",
                                             Callback::from(|_| {}), 
                                             false,
+                                            episode_url_for_ep_item,
                                         );
 
                                         item

--- a/web/src/components/home.rs
+++ b/web/src/components/home.rs
@@ -313,6 +313,7 @@ pub fn episode(props: &EpisodeProps) -> Html {
     };
     
     let datetime = parse_date(&props.episode.EpisodePubDate, &state.user_tz);
+    let episode_url_for_ep_item = episode_url_clone.clone();
     // let datetime = parse_date(&episode.EpisodePubDate, &state.user_tz, &state.date_format);
     let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
     let item = episode_item(
@@ -328,6 +329,7 @@ pub fn episode(props: &EpisodeProps) -> Html {
         "home",
         Callback::from(|_| {}), 
         false,
+        episode_url_for_ep_item,
     );
 
     item

--- a/web/src/components/podcast_layout.rs
+++ b/web/src/components/podcast_layout.rs
@@ -334,7 +334,6 @@ pub fn podcast_item(props: &PodcastProps) -> Html {
     // let button_class = if is_added { "bg-red-500" } else { "bg-blue-500" };
     let is_added = added_podcasts.contains(&podcast.url);
     let button_text = if is_added { "delete" } else { "add" };
-    let button_class = if is_added { "bg-red-500" } else { "bg-blue-500" };
     
     let on_title_click = {
         let dispatch = dispatch.clone();
@@ -424,12 +423,14 @@ pub fn podcast_item(props: &PodcastProps) -> Html {
             {
                 html! {
                     <div class="item-container border-solid border flex items-start mb-4 shadow-md rounded-lg h-full">
-                        <img 
-                            src={podcast.image.clone()}
-                            onclick={on_title_click.clone()}
-                            alt={format!("Cover for {}", podcast.title.clone())} 
-                            class="object-cover align-top-cover w-full item-container img"
-                        />
+                        <div class="flex flex-col w-auto object-cover pl-4">
+                            <img 
+                                src={podcast.image.clone()}
+                                onclick={on_title_click.clone()}
+                                alt={format!("Cover for {}", podcast.title.clone())} 
+                                class="object-cover align-top-cover w-full item-container img"
+                            />
+                        </div> 
                         <div class="flex items-start flex-col p-4 space-y-2 w-11/12">
                             <p class="item_container-text text-xl font-semibold cursor-pointer" onclick={on_title_click.clone()}>
                             { &podcast.title } </p>
@@ -448,7 +449,7 @@ pub fn podcast_item(props: &PodcastProps) -> Html {
                             }
                             <p class="header-text">{ format!("Episode Count: {}", &podcast.episodeCount) }</p>
                         </div>
-                        <button class={format!("item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full self-center mr-8 {}", button_class)} style="width: 60px; height: 60px;">
+                        <button class={format!("item-container-button border selector-button font-bold py-2 px-4 rounded-full self-center mr-8")} style="width: 60px; height: 60px;">
                             <span class="material-icons" onclick={toggle_podcast}>{ button_text }</span>
                             // { button_text }
                         </button>

--- a/web/src/components/podcasts.rs
+++ b/web/src/components/podcasts.rs
@@ -299,7 +299,7 @@ pub fn podcasts() -> Html {
                                             }
                                             <p class="item_container-text">{ format!("Episode Count: {}", &podcast.EpisodeCount) }</p>
                                         </div>
-                                        <button class={"item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full self-center mr-8"} style="width: 60px; height: 60px;">
+                                        <button class={"item-container-button border selector-button font-bold py-2 px-4 rounded-full self-center mr-8"} style="width: 60px; height: 60px;">
                                             <span class="material-icons" onclick={on_remove_click}>{"delete"}</span>
                                         </button>
                                     

--- a/web/src/components/podcasts.rs
+++ b/web/src/components/podcasts.rs
@@ -302,12 +302,6 @@ pub fn podcasts() -> Html {
                                         <button class={"item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full self-center mr-8"} style="width: 60px; height: 60px;">
                                             <span class="material-icons" onclick={on_remove_click}>{"delete"}</span>
                                         </button>
-                                        // <button
-                                        //     class="item-container-button border-solid border selector-button font-bold py-2 px-4 rounded-full flex items-center justify-center md:w-16 md:h-16 w-10 h-10"
-                                        //     onclick={on_remove_click}
-                                        // >
-                                        //     <span class="material-bonus-color material-icons large-material-icons md:text-6xl text-4xl">{"delete"}</span>
-                                        // </button>
                                     
                                     </div>
                                 </div>

--- a/web/src/components/queue.rs
+++ b/web/src/components/queue.rs
@@ -238,7 +238,7 @@ pub fn queue() -> Html {
                                 dispatch.clone(),
                                 episode_id_for_closure.clone(),
                             );
-
+                            let episode_url_for_ep_item = episode_url_clone.clone();
                             let date_format = match_date_format(state.date_format.as_deref());
                             let datetime = parse_date(&episode.EpisodePubDate, &state.user_tz);
                             let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
@@ -255,6 +255,7 @@ pub fn queue() -> Html {
                                 "queue",
                                 Callback::from(|_| {}), 
                                 false,
+                                episode_url_for_ep_item
                             );
 
                             item

--- a/web/src/components/saved.rs
+++ b/web/src/components/saved.rs
@@ -281,19 +281,19 @@ pub fn saved() -> Html {
                     }
                 }
             }
-        {
-            if let Some(audio_props) = &audio_state.currently_playing {
-                html! { <AudioPlayer src={audio_props.src.clone()} title={audio_props.title.clone()} artwork_url={audio_props.artwork_url.clone()} duration={audio_props.duration.clone()} episode_id={audio_props.episode_id.clone()} duration_sec={audio_props.duration_sec.clone()} start_pos_sec={audio_props.start_pos_sec.clone()} /> }
-            } else {
-                html! {}
-            }
-        }
         // Conditional rendering for the error banner
         if let Some(error) = error_message {
             <div class="error-snackbar">{ error }</div>
         }
         if let Some(info) = info_message {
             <div class="info-snackbar">{ info }</div>
+        }
+        {
+            if let Some(audio_props) = &audio_state.currently_playing {
+                html! { <AudioPlayer src={audio_props.src.clone()} title={audio_props.title.clone()} artwork_url={audio_props.artwork_url.clone()} duration={audio_props.duration.clone()} episode_id={audio_props.episode_id.clone()} duration_sec={audio_props.duration_sec.clone()} start_pos_sec={audio_props.start_pos_sec.clone()} /> }
+            } else {
+                html! {}
+            }
         }
         </div>
         <App_drawer />

--- a/web/src/components/saved.rs
+++ b/web/src/components/saved.rs
@@ -252,7 +252,7 @@ pub fn saved() -> Html {
                                 let date_format = match_date_format(state.date_format.as_deref());
                                 let datetime = parse_date(&episode.EpisodePubDate, &state.user_tz);
                                 let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
-    
+                                let episode_url_for_ep_item = episode_url_clone.clone();
                                 let item = episode_item(
                                     Box::new(episode),
                                     description.clone(),
@@ -266,6 +266,7 @@ pub fn saved() -> Html {
                                     "saved",
                                     Callback::from(|_| {}), 
                                     false,
+                                    episode_url_for_ep_item
                                 );
 
                                 item

--- a/web/src/components/search.rs
+++ b/web/src/components/search.rs
@@ -279,7 +279,7 @@ pub fn search(_props: &SearchProps) -> Html {
                                     let date_format = match_date_format(state.date_format.as_deref());
                                     let datetime = parse_date(&episode.EpisodePubDate, &state.user_tz);
                                     let format_release = format!("{}", format_datetime(&datetime, &state.hour_preference, date_format));
-                                    
+                                    let episode_url_for_ep_item = episode_url_clone.clone();
                                     let item = episode_item(
                                         Box::new(episode),
                                         description.clone(),
@@ -293,6 +293,7 @@ pub fn search(_props: &SearchProps) -> Html {
                                         "search",
                                         Callback::from(|_| {}), 
                                         false,
+                                        episode_url_for_ep_item,
                                     );
 
                                     item

--- a/web/src/components/setting_components/mod.rs
+++ b/web/src/components/setting_components/mod.rs
@@ -11,4 +11,5 @@ pub mod user_self_service;
 pub mod email_settings;
 pub mod backup_server;
 pub mod restore_server;
+pub mod custom_feed;
 // ...other submodule declarations if any...

--- a/web/src/components/settings.rs
+++ b/web/src/components/settings.rs
@@ -73,15 +73,15 @@ pub fn accordion_item(AccordionItemProps { title, content, position }: &Accordio
     let arrow_rotation_class = if *is_open { "rotate-180" } else { "rotate-0" };
 
     html! {
-        <div class={format!("border border-gray-200 dark:border-gray-700 {}", border_class)}>
+        <div class={format!("border border-gray-200 dark:border-gray-700 accordion-container {}", border_class)}>
             <h2>
                 <button
-                    class={format!("flex accordion-header items-center justify-between w-full p-5 font-medium {} focus:ring-4 gap-3", button_class)}
+                    class={format!("accordion-button flex items-center justify-between w-full p-5 font-medium {} focus:ring-4 gap-3 relative", button_class)}
                     onclick={toggle}
                 >
                     <span>{ title }</span>
                     <svg
-                        class={format!("w-3 h-3 shrink-0 transition-transform duration-300 {}", arrow_rotation_class)}
+                        class={format!("w-3 h-3 shrink-0 transition-transform duration-300 accordion-arrow {}", arrow_rotation_class)}
                         xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6"
                     >
                         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5"/>
@@ -226,6 +226,7 @@ pub fn settings() -> Html {
                         <AccordionItem title="MFA Settings" content={html!{ <setting_components::mfa_settings::MFAOptions /> }} position={AccordionItemPosition::Middle}/>
                         <AccordionItem title="Export/Backup Podcasts" content={html!{ <setting_components::export_settings::ExportOptions /> }} position={AccordionItemPosition::Middle}/>
                         <AccordionItem title="Import Podcasts" content={html!{ <setting_components::import_options::ImportOptions /> }} position={AccordionItemPosition::Middle}/>
+                        <AccordionItem title="Add Custom Feed" content={html!{ <setting_components::custom_feed::CustomFeed /> }} position={AccordionItemPosition::Middle}/>
                         <AccordionItem title="Connect Nextcloud Podcast Sync" content={html!{ <setting_components::nextcloud_options::NextcloudOptions /> }} position={AccordionItemPosition::Middle}/>
                         <AccordionItem title="Api Keys" content={html!{ <setting_components::api_keys::APIKeys /> }} position={AccordionItemPosition::Middle}/>
                     </div>

--- a/web/src/requests/pod_req.rs
+++ b/web/src/requests/pod_req.rs
@@ -992,3 +992,67 @@ pub async fn call_get_podcast_id(
     let response_data: PodcastIdResponse = serde_json::from_str(&response_text)?;
     Ok(response_data.episodes)
 }
+
+fn explicit_from_int<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val: i32 = Deserialize::deserialize(deserializer)?;
+    Ok(val == 1) // 1 = true, 0 = false
+}
+
+
+#[derive(Deserialize, Debug, Clone, Serialize)]
+pub struct PodcastDetails {
+    #[serde(rename = "PodcastName")]
+    pub podcast_name: String,
+    #[serde(rename = "ArtworkURL")]
+    pub artwork_url: String,
+    #[serde(rename = "Author")]
+    pub author: String,
+    #[serde(rename = "Categories")]
+    pub categories: String,
+    #[serde(rename = "Description")]
+    pub description: String,
+    #[serde(rename = "EpisodeCount")]
+    pub episode_count: i32,
+    #[serde(rename = "FeedURL")]
+    pub feed_url: String,
+    #[serde(rename = "WebsiteURL")]
+    pub website_url: String,
+    #[serde(rename = "Explicit", deserialize_with = "explicit_from_int")]
+    pub explicit: bool,
+    #[serde(rename = "UserID")]
+    pub user_id: i32,
+}
+
+#[derive(Deserialize)]
+struct PodcastDetailsResponse {
+    details: PodcastDetails,
+}
+
+pub async fn call_get_podcast_details(
+    server_name: &str,
+    api_key: &str,
+    user_id: i32,
+    podcast_id: &i32,
+) -> Result<PodcastDetails, Error> {
+    let url = format!("{}/api/data/get_podcast_details?user_id={}&podcast_id={}", server_name, user_id, podcast_id);
+
+    let response = Request::get(&url)
+        .header("Content-Type", "application/json")
+        .header("Api-Key", api_key)
+        .send()
+        .await
+        .map_err(|e| Error::msg(format!("Network request error: {}", e)))?;
+
+    if response.ok() {
+        let response_data: PodcastDetailsResponse = response.json().await.map_err(|e| Error::msg(format!("Failed to parse response: {}", e)))?;
+        Ok(response_data.details)
+    } else {
+        Err(Error::msg(format!(
+            "Error retrieving podcast details. Server response: {}",
+            response.status_text()
+        )))
+    }
+}

--- a/web/src/requests/pod_req.rs
+++ b/web/src/requests/pod_req.rs
@@ -46,7 +46,6 @@ pub async fn call_get_recent_eps(server_name: &String, api_key: &Option<String>,
     
     // First, capture the response text for diagnostic purposes
     let response_text = response.text().await.unwrap_or_else(|_| "Failed to get response text".to_string());
-
     // Try to deserialize the response text
     match serde_json::from_str::<RecentEps>(&response_text) {
         Ok(response_body) => {

--- a/web/src/requests/setting_reqs.rs
+++ b/web/src/requests/setting_reqs.rs
@@ -1041,3 +1041,36 @@ pub async fn call_user_admin_check(
     }
 }
 
+#[derive(Serialize, Deserialize)]
+struct CustomFeedRequest {
+    feed_url: String,
+    user_id: i32,
+}
+
+pub async fn call_add_custom_feed(
+    server_name: &str,
+    feed_url: &str,
+    user_id: &i32,
+    api_key: &str,
+) -> Result<String, Error> {
+    let url = format!("{}/api/data/add_custom_podcast", server_name);
+    let request_body = CustomFeedRequest {
+        feed_url: feed_url.to_string().clone(),
+        user_id: user_id.clone(),
+    };
+    log::info!("url: {:?}", feed_url.to_string().clone());
+
+    let response = Request::post(&url)
+        .header("Content-Type", "application/json")
+        .header("Api-Key", api_key)
+        .body(serde_json::to_string(&request_body)?)?
+        .send()
+        .await
+        .map_err(Error::msg)?;
+
+    if response.ok() {
+        response.text().await.map_err(Error::msg)
+    } else {
+        Err(Error::msg(format!("Error adding feed: {}", response.status_text())))
+    }
+}

--- a/web/static/js_func.js
+++ b/web/static/js_func.js
@@ -31,3 +31,40 @@ window.toggleDescription = function(guid, shouldExpand) {
         console.error("Description container not found for GUID: " + guid);
     }
 }
+
+window.addEventListener('load', function() {
+    const descriptions = document.querySelectorAll('.item-header-description');
+    descriptions.forEach(desc => {
+        if (desc.scrollHeight > desc.clientHeight) {
+            const btn = desc.querySelector('.toggle-desc-btn');
+            btn.classList.remove('hidden');  // Show button if content is clipped
+        }
+    });
+});
+
+function toggle_description(guid) {
+    const selector = `#${guid.replace(/[^a-zA-Z0-9-]/g, '')}`; // Use ID selector
+    console.log("Trying to select:", selector);
+    const descContainer = document.querySelector(selector);
+
+    if (!descContainer) {
+        console.error("Description container not found for GUID: " + guid + " with selector: " + selector);
+        return;
+    }
+
+    const button = descContainer.querySelector('.toggle-desc-btn');
+    if (!button) {
+        console.error("Button not found in description container for GUID: " + guid);
+        return;
+    }
+
+    if (descContainer.classList.contains('desc-collapsed')) {
+        descContainer.classList.remove('desc-collapsed');
+        descContainer.classList.add('desc-expanded');
+        button.textContent = '';
+    } else {
+        descContainer.classList.add('desc-collapsed');
+        descContainer.classList.remove('desc-expanded');
+        button.textContent = '';
+    }
+}

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -283,7 +283,6 @@ body {
     height: 60px; /* Initial height */
     background-color: var(--secondary-background);
     color: white;
-    padding: 10px 20px;
     display: flex;
     box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.3);
     z-index: 1000; /* Ensure it's on top */
@@ -341,6 +340,94 @@ body {
     align-items: center;
 }
 
+.audio-player .line-content {
+    padding: 10px 20px;
+    box-sizing: border-box;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        visibility: hidden;
+    }
+    to {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+.playback-speed-display {
+    position: relative; 
+    width: 100%;
+    padding: 10px 0; 
+}
+
+.speed-text {
+    position: absolute;
+    left: 215px;
+    top: 50%;
+    transform: translateY(-50%); 
+    z-index: 1;
+}
+
+.slider {
+    width: 100%; 
+    display: block; 
+    margin: auto; 
+}
+
+@media (max-width: 768px) {
+    .speed-text {
+        position: relative;
+        left: auto; 
+        top: auto;  
+        transform: none;  
+        text-align: center; 
+        display: block;
+        width: 100%;  
+        margin-bottom: 10px; 
+    }
+
+    .speed-display-container {
+        flex-direction: column-reverse; 
+        align-items: center;  
+    }
+}
+
+
+
+
+.playback-speed-display {
+    animation: fadeIn 0.3s ease-out forwards;
+    opacity: 0;
+    visibility: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        visibility: visible;
+    }
+    to {
+        opacity: 0;
+        visibility: hidden;
+    }
+}
+
+.playback-speed-display.hidden {
+    animation: fadeOut 0.3s ease-out forwards;
+}
+
+
+.playback-speed-display.visible {
+    animation-name: fadeIn; /* Only change the animation name to trigger it */
+}
+
+
+
 .audio-player .line-content .right-group {
     justify-content: flex-end;
     padding-right: 25px;
@@ -371,7 +458,7 @@ body {
 .audio-player .top-section .retract-button {
     position: absolute;
     top: 70px; /* Adjust as needed */
-    left: 7px; /* Adjust as needed */
+    left: 25px; /* Adjust as needed */
     border: none; /* Remove the border */
     background: none; /* Remove the background */
     padding: 0; /* Remove the padding */
@@ -392,19 +479,19 @@ body {
     height: 100%;
 }
 
+.audio-image-container {
+    display: flex;
+    justify-content: center;
+}
+
 .audio-player.expanded .line-content,
 .audio-player.expanded .top-section {
     transition: visibility 0s 0.5s, opacity 0.5s linear;
 }
 
-.audio-full-button {
-    margin-top: 15px;
-}
-
 
 .audio-player button {
-    background-color: var(--button-color); /* Button background color */
-    color: white; /* Button text color */
+    background-color: transparent; /* Button background color */
     padding: 10px 15px; /* Padding inside the button */
     margin-right: 20px; /* Margin to the right */
     cursor: pointer; /* Cursor as pointer */
@@ -421,6 +508,11 @@ body {
     flex-basis: 90%; /* Adjust as needed */
 }
 
+.audio-player .top-section {
+    display: flex;
+    justify-content: center;
+}
+
 .audio-player .top-section .title {
     font-size: 2em; /* Make the title larger */
     text-align: center;
@@ -428,15 +520,15 @@ body {
 }
 
 .audio-player .top-section .scrub-bar {
-    display: flex; /* Align elements in a row */
-    align-items: center; /* Center align vertically */
-    justify-content: space-between; /* Space out the elements */
-    width: 60%;;
-    padding: 10px 20px; /* Padding for breathing space */
-    font-size: 0.9em; /* Adjust font size for time display */
-    /* color: var(--prog-bar-color); Text color */
-    margin: 10px 0; /* Vertical margin */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%; /* Adjusted to take full width of its container */
+    padding: 10px 20px;
+    font-size: 0.9em;
+    margin: 10px auto; /* Adjusted to auto to center within its container */
 }
+
 
 .audio-player .top-section .scrub-bar span {
     flex-shrink: 0; /* Prevent shrinking */
@@ -815,12 +907,33 @@ body {
     }
 }
 
+.episode-button-container {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center; /* Centers button horizontally */
+    line-height: 1;
+}
 
-
-
-
-
-
+@media (max-width: 768px) { /* Adjust breakpoint as needed */
+    /* Styling for the button container */
+    .episode-button-container {
+        display: flex;
+        flex-basis: 15%; /* Adjust this percentage based on your design needs */
+        flex-grow: 0;
+        flex-shrink: 0;
+        align-items: center; /* Center align the buttons vertically */
+        justify-content: center; /* Center align the buttons horizontally */
+        padding: 8px;
+        gap: 8px; /* Space between buttons */
+    }
+    .episode-button-container button {
+        border-radius: 30px; /* Fully rounded borders */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none; /* Remove border */
+    }
+}
 
 .item-container img {
     width: 100%;
@@ -856,6 +969,15 @@ body {
     color: var(--standout-color);
     /*background-color: var(--accent-color);*/
     cursor: pointer;
+}
+
+.audio-top-button {
+    color: var(--text-secondary-color);
+    background-color: transparent;
+}
+
+.audio-top-button.selector-button:hover {
+    background-color: var(--hover-color); /* Replace #your-hover-color with your desired color */
 }
 
 .item-container-button {
@@ -1293,6 +1415,19 @@ button.item-container-action-button.item-container-action-button {
     align-items: start;
     margin-bottom: 20px;
 }
+
+@media (max-width: 768px) {
+    .episode-layout-container {
+        padding-top: 70px; /* Increase padding for smaller screens if necessary */
+    }
+}
+
+@media (max-height: 500px) {
+    .episode-layout-container {
+        padding-top: 80px; /* Increase padding for very small height screens */
+    }
+}
+
 
 .episode-artwork {
     /* Adjust to scale with page size */

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -609,7 +609,7 @@ body {
 
 .item-header {
     display: flex;
-    align-items: center; /* Ensure items are centered vertically */
+    align-items: start; /* Ensure items are centered vertically */
     background-color: var(--bonus-color);
     padding: 20px;
     margin-bottom: 20px;
@@ -652,6 +652,13 @@ body {
     font-weight: bold;
     margin-bottom: 10px;
     color: var(--text-color);
+    margin-right: 20px; /* Adds space between title and button */
+}
+
+.title-button-container {
+    display: flex;
+    align-items: center;
+    width: 100%; /* Ensures the container takes full width */
 }
 
 .item-header-description {
@@ -744,6 +751,17 @@ body {
     max-height: 50px; /* or whatever max height you determine */
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.desc-pod-collapsed {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 5; /* Limit to 3 lines initially */
+    -webkit-box-orient: vertical;
+}
+
+.desc-pod-expanded {
+    display: block;
 }
 
 

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -212,8 +212,7 @@ body {
 .search-btn {
     background-color: transparent;
     color: var(--text-color);
-    border-radius: 4px;
-    border-color: var(--border-color);
+    border-color: transparent; /* Set border color to transparent */
     cursor: pointer;
 }
 
@@ -231,10 +230,16 @@ body {
     padding-bottom: 20px;
     background-color: var(--transparent-background);
     backdrop-filter: blur(10px);
+    /* Add margin to the bottom to space out the elements */
+    margin-bottom: 10px;
 }
 
 .search-drop-button {
     color: var(--text-color);
+    /* Add margin to the right to space out the buttons */
+    margin-right: 10px;
+    /* Add padding to the bottom of the button */
+    padding-bottom: 10px;
 }
 
 .search-drop-button:hover {
@@ -1084,11 +1089,31 @@ button.item-container-action-button.item-container-action-button {
     color: --var(--text-color);
 }
 
-/* Hover background color for accordion header */
-.accordion-header:hover {
-    background-color: var(--hover-color); /* Example color, adjust as needed */
-    color: var(--text-color);
+/* Background color for accordion arrow */
+.accordion-arrow {
+    background-color: transparent; /* Transparent background */
+    position: relative; /* Relative position */
+    width: 24px; /* Define width */
+    height: 24px; /* Define height */
 }
+
+/* Hover background color for accordion arrow */
+/* Hover effect for the button, with a smaller circle */
+.accordion-button:hover::before {
+    content: "";
+    position: absolute;
+    top: 50%;  /* Center the circle vertically relative to the button */
+    left: 50%; /* Center the circle horizontally relative to the button */
+    transform: translate(-50%, -50%); /* Offset the centering to the exact middle */
+    left: calc(100% - 26px);
+    width: 30px; /* Smaller width, adjust based on your arrow or button size */
+    height: 30px; /* Smaller height, match width for circle */
+    background-color: var(--hover-color); /* Example color, adjust as needed */
+    border-radius: 50%; /* Rounded shape */
+    z-index: 0; /* Ensure it's visible above the button background but below text/icons */
+}
+
+
 
 /* Styles for the select dropdown */
 .theme-select-dropdown {

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1346,6 +1346,24 @@ button.item-container-action-button.item-container-action-button {
     border-radius: 5px; /* Round the corners */
 }
 
+.no-media-warning {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3px 12px;  /* Adjust padding to match your buttons */
+    font-weight: bold;
+    margin-bottom: 10px;  /* Bottom padding as requested */
+}
+
+.episode-action-buttons .no-media-warning {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    width: 100%;
+}
+
+
 .episode-action-buttons .play-button {
     position: relative;
     top: -2px; /* Adjust this value as needed */

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -762,21 +762,67 @@ body {
 }
 
 .button-container {
-    display: flex;
+    display: flex !important;
+    align-items: center !important;
     justify-content: center; /* Centers button horizontally */
-    align-items: center;     /* Centers button vertically */
+    line-height: 1;
+}
+
+@media (max-width: 768px) { /* Adjust breakpoint as needed */
+    /* Styling for the button container */
+    .button-container {
+        display: flex;
+        flex-basis: 15%; /* Adjust this percentage based on your design needs */
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-direction: column;
+        align-items: center; /* Center align the buttons vertically */
+        justify-content: center; /* Center align the buttons horizontally */
+        padding: 8px;
+        gap: 8px; /* Space between buttons */
+    }
+    .button-container button {
+        width: 60px; /* Fixed width */
+        height: 60px; /* Fixed height */
+        border-radius: 30px; /* Fully rounded borders */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none; /* Remove border */
+    }
 }
 
 
 
 
+
+
+
+
 .item-container img {
-    max-width: 200px; /* Adjust this value as needed */
-    max-height: 200px; /* Adjust this value as needed */
-    object-fit: cover; /* This will ensure the image covers the area without stretching */
+    width: 100%;
+    max-width: 200px;
+    max-height: 200px;
+    object-fit: cover;
     align-self: flex-start;
     margin-top: 10px;
+    margin-bottom: 10px;
     border-radius: 10px;
+}
+
+@media (max-width: 768px) { /* Adjust breakpoint as needed */
+    .item-container img {
+        max-width: 150px; /* Smaller max width for smaller screens */
+        max-height: 150px; /* Smaller max height for smaller screens */
+        width: 150px;
+        height: 150px;
+    }
+}
+
+/* Additional styles for better alignment and consistency */
+.item-container {
+    align-items: center; /* Align items vertically */
+    justify-content: center; /* Center items horizontally */
 }
 
 .item_container-text {
@@ -797,6 +843,13 @@ body {
 
 .item-container-button.selector-button:hover {
     background-color: var(--hover-color); /* Replace #your-hover-color with your desired color */
+}
+
+/* Media query for smaller screens */
+@media (max-width: 768px) {
+    .item-container-button {
+        border: none; /* Remove border on small screens */
+    }
 }
 
 .item-container-alert-button {
@@ -894,9 +947,15 @@ button.item-container-action-button.item-container-action-button {
 }
 
 .large-card-image {
-    max-width: 50%;
     height: auto;
     border-radius: 0.5rem;
+    width: 100%;
+    max-width: 200px;
+    max-height: 200px;
+    object-fit: cover;
+    align-self: center !important;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .large-card-content {
@@ -933,13 +992,21 @@ button.item-container-action-button.item-container-action-button {
 }
 
 .search-page-input {
-    width: 50%;
+    width: 60%;
     transition: all 1s ease-in-out;
     position: absolute;
     top: 40%; /* Start from the center of the screen */
     left: 50%; /* Start from the center of the screen */
     transform: translate(-50%, -50%); /* Move up and left by half of its own width and height */
     z-index: 1; /* Ensure it's on top */
+}
+
+/* Styles for smaller screens */
+@media (max-width: 768px) {
+    .search-page-input {
+        width: 90%; /* Increase width to 90% of the viewport */
+
+    }
 }
 
 .search-page-input.move-to-top {


### PR DESCRIPTION
Version 0.6.3

- [x] Fix appearance and layout of podcasts on podcast screen or on searching pages. (Also added additional see more type dropdowns for descriptions to make them fit better.)
- [x] Fix mobile experience to make images consistently sized
- [x] Fixed layout of pinepods logo on user stats screen
- [x] Expanded the search bar on search podcasts page for small screens. It was being cut off a bit
- [x] Fixed order of history page
- [x] Downloads page typo
- [x] Improve look of search podcast dropdown on small screens
- [x] Made the setting accordion hover effect only over the arrows.
- [x] Added area in the settings to add custom podcast feeds
- [x] Added a Pinepods news feed that gets automatically subscribed to on fresh installs. You can easily unsubscribe from this if you don't care about it
- [x] Added ability to access episodes for an entire podcast from the episode display screen (click the podcast name)
- [x] Created functionality so the app can handle when a feed doesn't contain an audio file
- [x] Added playback speed button in the episode playing page. Now you can make playback faster!
- [x] Added episode skip button in the episode playing page. Skips to the next in the queue.
- [x] Fixed issue with the reverse button in the episode page so that it now reverses the playback by 15 seconds.
- [x] Fixed issue where spacebar didn't work in app when episode was playing
- [x] Added and verified support for mysql databases. Thanks @rgarcia6520