### PR TITLE
fix: Change database name in sample postgres compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ services:
   db:
     image: postgres:latest
     environment:
-      POSTGRES_DB: pypods_database
+      POSTGRES_DB: pinepods_database
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: myS3curepass
       PGDATA: /var/lib/postgresql/data/pgdata


### PR DESCRIPTION
Spinning up a container with the sample postgres file results in these errors:
`db-1        | 2024-07-21 11:30:01.626 UTC [72] FATAL:  database "pinepods_database" does not exist`

Assume this is a legacy issue from when you renamed the project.