### PR TITLE
Fixes to episode_layout refreshing to keep context and sharable links

### DIFF
--- a/clients/clientapi.py
+++ b/clients/clientapi.py
@@ -653,6 +653,7 @@ async def get_podcast_details(
 
         if categories.startswith('{'):
             try:
+                categories = categories.replace("'", '"')
                 categories_dict = json.loads(categories)
             except json.JSONDecodeError as e:
                 print(f"JSON decode error: {e}")
@@ -690,15 +691,29 @@ async def get_podcast_details(
     else:
         print("podcast not added")
         podcast_values = database_functions.app_functions.get_podcast_values(podcast_url, user_id)
+        categories = podcast_values['categories']
+
+        if categories.startswith('{'):
+            try:
+                # Replace single quotes with double quotes
+                categories = categories.replace("'", '"')
+                categories_dict = json.loads(categories)
+            except json.JSONDecodeError as e:
+                print(f"JSON decode error: {e}")
+                raise HTTPException(status_code=500, detail="Internal server error")
+        else:
+            categories_dict = {str(i): cat.strip() for i, cat in enumerate(categories.split(','))}
+
+
         return ClickedFeedURL(
             podcast_title=podcast_values['pod_title'],
-            podcast_url=podcast_values['pod_url'],
+            podcast_url=podcast_values['pod_feed_url'],
             podcast_description=podcast_values['pod_description'],
             podcast_author=podcast_values['pod_author'],
             podcast_artwork=podcast_values['pod_artwork'],
             podcast_explicit=podcast_values['pod_explicit'],
             podcast_episode_count=podcast_values['pod_episode_count'],
-            podcast_categories=podcast_values['categories'],
+            podcast_categories=categories_dict,
             podcast_link=podcast_values['pod_website'],
         )
 

--- a/clients/clientapi.py
+++ b/clients/clientapi.py
@@ -48,6 +48,7 @@ sys.path.append('/pinepods')
 
 import database_functions.functions
 import database_functions.auth_functions
+import database_functions.app_functions
 
 database_type = str(os.getenv('DB_TYPE', 'mariadb'))
 if database_type == "postgresql":
@@ -270,7 +271,6 @@ def check_if_admin_inner(api_key: str, cnx):
 
     if not user_id:
         return False
-    print("checking admin")
     return database_functions.functions.user_admin_check(cnx, database_type, user_id)
 
 
@@ -610,6 +610,97 @@ async def api_podcast_id(podcast_id: str = Query(...), cnx=Depends(get_database_
         raise HTTPException(status_code=403,
                             detail="You can only return pocast ids of your own podcasts!")
 
+class ClickedFeedURL(BaseModel):
+    podcast_title: str
+    podcast_url: str
+    podcast_description: str
+    podcast_author: str
+    podcast_artwork: str
+    podcast_explicit: bool
+    podcast_episode_count: int
+    podcast_categories: Optional[Dict[str, str]]
+    podcast_link: str
+
+@app.get("/api/data/get_podcast_details_dynamic", response_model=ClickedFeedURL)
+async def get_podcast_details(
+    user_id: int,
+    podcast_title: str,
+    podcast_url: str,
+    added: bool,
+    cnx=Depends(get_database_connection),
+    api_key: str = Depends(get_api_key_from_header),
+):
+    is_valid_key = database_functions.functions.verify_api_key(cnx, database_type, api_key)
+    if not is_valid_key:
+        raise HTTPException(status_code=403, detail="Invalid API key or insufficient permissions")
+
+    if added:
+        print("podcast added")
+        print(f"podcast url: {podcast_url}")
+        print(f"podcast name: {podcast_title}")
+        podcast_id = database_functions.functions.get_podcast_id(database_type, cnx, user_id, podcast_url, podcast_title)
+        print(f"heres the id: {podcast_id}")
+        details = database_functions.functions.get_podcast_details(database_type, cnx, user_id, podcast_id)
+        print(f"got the details: {details}")
+        if details is None:
+            raise HTTPException(status_code=404, detail="Podcast not found")
+
+        # Handle categories field
+        if database_type == "postgresql":
+            categories = details["categories"]
+        else:
+            categories = details["Categories"]
+
+        if categories.startswith('{'):
+            try:
+                categories_dict = json.loads(categories)
+            except json.JSONDecodeError as e:
+                print(f"JSON decode error: {e}")
+                raise HTTPException(status_code=500, detail="Internal server error")
+        else:
+            categories_dict = {str(i): cat.strip() for i, cat in enumerate(categories.split(','))}
+
+
+        if database_type == 'postgresql':
+            pod_details = ClickedFeedURL(
+                podcast_title=details["podcastname"],
+                podcast_url=details["feedurl"],
+                podcast_description=details["description"],
+                podcast_author=details["author"],
+                podcast_artwork=details["artworkurl"],
+                podcast_explicit=details["explicit"],
+                podcast_episode_count=details["episodecount"],
+                podcast_categories=categories_dict,
+                podcast_link=details["websiteurl"],
+            )
+        else:
+            pod_details = ClickedFeedURL(
+                podcast_title=details["PodcastName"],
+                podcast_url=details["FeedURL"],
+                podcast_description=details["Description"],
+                podcast_author=details["Author"],
+                podcast_artwork=details["ArtworkURL"],
+                podcast_explicit=details["Explicit"],
+                podcast_episode_count=details["EpisodeCount"],
+                podcast_categories=categories_dict,
+                podcast_link=details["WebsiteURL"],
+            )
+
+        return pod_details
+    else:
+        print("podcast not added")
+        podcast_values = database_functions.app_functions.get_podcast_values(podcast_url, user_id)
+        return ClickedFeedURL(
+            podcast_title=podcast_values['pod_title'],
+            podcast_url=podcast_values['pod_url'],
+            podcast_description=podcast_values['pod_description'],
+            podcast_author=podcast_values['pod_author'],
+            podcast_artwork=podcast_values['pod_artwork'],
+            podcast_explicit=podcast_values['pod_explicit'],
+            podcast_episode_count=podcast_values['pod_episode_count'],
+            podcast_categories=podcast_values['categories'],
+            podcast_link=podcast_values['pod_website'],
+        )
 
 class PodcastFeedData(BaseModel):
     podcast_feed: str
@@ -984,7 +1075,6 @@ async def api_add_podcast(podcast_values: PodcastValuesModel,
             gpodder_url, gpodder_token, gpodder_login = database_functions.functions.get_nextcloud_settings(database_type, cnx, podcast_values.user_id)
             print(f"Adding podcast to Nextcloud: {gpodder_url}, {gpodder_login}, {gpodder_token}, {podcast_values.pod_feed_url}")
             gpod_type = database_functions.functions.get_gpodder_type(cnx, database_type, podcast_values.user_id)
-            print(f"Type of podsync {gpod_type}")
             if gpod_type == "nextcloud":
                 database_functions.functions.add_podcast_to_nextcloud(cnx, database_type, gpodder_url, gpodder_login, gpodder_token, podcast_values.pod_feed_url)
             else:
@@ -1541,13 +1631,10 @@ async def api_check_podcast(
 async def api_user_admin_check_route(user_id: int, api_key: str = Depends(get_api_key_from_header),
                                      cnx=Depends(get_database_connection)):
     is_valid_key = database_functions.functions.verify_api_key(cnx, database_type, api_key)
-    print("validated key")
     if not is_valid_key:
         raise HTTPException(status_code=403,
                             detail="Your API key is either invalid or does not have correct permission")
-    print("running elevated access")
     elevated_access = await has_elevated_access(api_key, cnx)
-    print("post access")
     if not elevated_access:
         # Get user ID from API key
         user_id_from_api_key = database_functions.functions.id_from_api_key(cnx, database_type, api_key)
@@ -1585,7 +1672,6 @@ async def api_remove_podcast_route(data: RemovePodcastData = Body(...), cnx=Depe
     if database_functions.functions.check_gpodder_settings(database_type, cnx, data.user_id):
         gpodder_url, gpodder_token, gpodder_login = database_functions.functions.get_nextcloud_settings(database_type, cnx, data.user_id)
         gpod_type = database_functions.functions.get_gpodder_type(cnx, database_type, podcast_values.user_id)
-        print(f"Type of podsync {gpod_type}")
         if gpod_type == "nextcloud":
             database_functions.functions.remove_podcast_from_nextcloud(cnx, database_type, gpodder_url, gpodder_login, gpodder_token, data.podcast_url)
         else:
@@ -1623,7 +1709,6 @@ async def api_remove_podcast_route_id(data: RemovePodcastIDData = Body(...), cnx
         logging.info('em cloud')
         podcast_feed = database_functions.functions.get_podcast_feed_by_id(cnx, database_type, data.podcast_id)
         gpod_type = database_functions.functions.get_gpodder_type(cnx, database_type, data.user_id)
-        print(f"Type of podsync {gpod_type}")
         if gpod_type == "nextcloud":
             database_functions.functions.remove_podcast_from_nextcloud(cnx, database_type, gpodder_url, gpodder_login, gpodder_token, podcast_feed)
         else:
@@ -2145,7 +2230,6 @@ async def api_get_api_info(cnx=Depends(get_database_connection), api_key: str = 
     if not is_valid_key:
         raise HTTPException(status_code=403,
                             detail="Your API key is either invalid or does not have correct permission")
-    print('getting elevate')
     elevated_access = await has_elevated_access(api_key, cnx)
 
     if not elevated_access:
@@ -3140,8 +3224,7 @@ async def refresh_nextcloud_subscription(background_tasks: BackgroundTasks, is_a
                 gpodder_login = user["GpodderLoginName"]
         else:  # assuming tuple
             user_id, gpodder_url, gpodder_token, gpodder_login = user
-        
-        print(f"userid: {user_id}")
+
         background_tasks.add_task(refresh_nextcloud_subscription_for_user, database_type, user_id, gpodder_url, gpodder_token, gpodder_login)
 
     return {"status": "success", "message": "Nextcloud subscriptions refresh initiated."}
@@ -3252,7 +3335,6 @@ async def stream_episode(
     # Allow the action if the API key belongs to the user or it's the web API key
     if key_id == user_id or is_web_key:
         file_path = database_functions.functions.get_download_location(cnx, database_type, episode_id, user_id)
-        print(file_path)
         if file_path:
             return FileResponse(path=file_path, media_type='audio/mpeg', filename=os.path.basename(file_path))
         else:

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -14,7 +14,9 @@ Next Minor Version:
 - [] Test with LXC containers
 - [] Queue adjmustment for mobile devices
 - [] Full Show deletion with checkbox on download page
-
+- [] Added a People page so that you can see other episodes and podcasts a particular person has been on
+- [] Manually adjust tags for podcast in podcast settings
+- [] Update Feed directly after adding a Nextcloud/gpodder sync server instead of waiting for the next refresh
 
 Version 0.6.4
 
@@ -22,10 +24,10 @@ Version 0.6.4
 - [x] Added a new route for the version tag that dynamically updates when the application is compiled. This allows for automation around the version numbers all based around the the Github release tag as the original source of truth.
 - [] Fixed layout for podcasts when searching
 - [] Support floating point chapters
-- [] Update Feed directly after adding a Nextcloud/gpodder sync server instead of waiting for the next refresh
-- [] Added a People page so that you can see other episodes and podcasts a particular person has been on
-- [] Manually adjust tags for podcast in podcast settings
-
+- [x] Fixed issue with white space at the bottom of every page #229
+- [x] Cleaned up incorrect or not needed logging at startup #219
+- [x] Fixed issue with user stats page where it would lose user context on reload #135
+- [x] Fixed issue with settings page where it would lose user context on reload #134
 
 Version 0.6.3
 

--- a/database_functions/functions.py
+++ b/database_functions/functions.py
@@ -722,14 +722,8 @@ def return_podcast_episodes(database_type, cnx, user_id, podcast_id):
     rows = cursor.fetchall()
     cursor.close()
 
-    logging.error(f"Raw rows before normalization: {rows}")
-
     # Normalize keys
     rows = capitalize_keys(rows)
-
-    logging.error(f"Raw rows after normalization: {rows}")
-
-    logging.debug(f"Rows after normalization: {rows}")
 
     return rows or None
 
@@ -740,6 +734,7 @@ def get_podcast_details(database_type, cnx, user_id, podcast_id):
     else:  # Assuming MariaDB/MySQL if not PostgreSQL
         cursor = cnx.cursor(dictionary=True)
 
+    print(f"pulling pod deets for {podcast_id}")
     if database_type == "postgresql":
         query = """
             SELECT *

--- a/web/src/components/click_events.rs
+++ b/web/src/components/click_events.rs
@@ -1,7 +1,10 @@
 use crate::components::context::AppState;
 use crate::components::podcast_layout::ClickedFeedURL;
-use crate::requests::pod_req::{call_check_podcast, call_get_podcast_id};
-use crate::requests::search_pods::{call_get_podcast_episodes, call_parse_podcast_url};
+use crate::requests::pod_req::{call_check_podcast, call_get_podcast_details, call_get_podcast_id};
+use crate::requests::search_pods::{
+    call_get_podcast_episodes, call_parse_podcast_channel_info, call_parse_podcast_url,
+};
+use anyhow::Error;
 use std::collections::HashMap;
 use web_sys::MouseEvent;
 use yew::Callback;
@@ -138,4 +141,66 @@ pub fn create_on_title_click(
             };
         });
     })
+}
+
+pub async fn get_podcast_values(
+    server_name: &str,
+    api_key: &str,
+    user_id: i32,
+    podcast_title: &str,
+    podcast_url: &str,
+    added: bool,
+) -> Result<ClickedFeedURL, Error> {
+    if added {
+        // Fetch podcast details using podcast id
+        let podcast_id = call_get_podcast_id(
+            server_name,
+            &Some(api_key.to_string()),
+            &user_id,
+            podcast_url,
+            podcast_title,
+        )
+        .await?;
+        let podcast_details =
+            call_get_podcast_details(server_name, api_key, user_id, &podcast_id).await?;
+        Ok(ClickedFeedURL {
+            podcast_title: podcast_details.podcastname,
+            podcast_url: podcast_details.feedurl,
+            podcast_description: podcast_details.description,
+            podcast_author: podcast_details.author,
+            podcast_artwork: podcast_details.artworkurl,
+            podcast_explicit: podcast_details.explicit,
+            podcast_episode_count: podcast_details.episodecount,
+            podcast_categories: Some(
+                podcast_details
+                    .categories
+                    .split(", ")
+                    .enumerate()
+                    .map(|(i, cat)| (i.to_string(), cat.to_string()))
+                    .collect(),
+            ),
+            podcast_link: podcast_details.websiteurl,
+        })
+    } else {
+        // Parse the podcast URL to get the details using the existing function
+        let podcast_info = call_parse_podcast_channel_info(podcast_url).await?;
+        Ok(ClickedFeedURL {
+            podcast_title: podcast_info.title,
+            podcast_url: podcast_url.to_string(),
+            podcast_description: podcast_info.description,
+            podcast_author: podcast_info.author,
+            podcast_artwork: podcast_info.artwork_url.unwrap_or_default(),
+            podcast_explicit: podcast_info.explicit,
+            podcast_episode_count: podcast_info.episode_count,
+            podcast_categories: Some(
+                podcast_info
+                    .categories
+                    .iter()
+                    .enumerate()
+                    .map(|(i, cat)| (i.to_string(), cat.to_string()))
+                    .collect(),
+            ),
+            podcast_link: podcast_info.website,
+        })
+    }
 }

--- a/web/src/components/podcast_layout.rs
+++ b/web/src/components/podcast_layout.rs
@@ -1,5 +1,5 @@
 use super::app_drawer::App_drawer;
-use super::gen_components::{Search_nav, UseScrollToTop};
+use super::gen_components::{Search_nav, empty_message, UseScrollToTop};
 use crate::components::audio::AudioPlayer;
 use crate::components::context::{AppState, ExpandedDescriptions, UIState};
 use crate::components::episodes_layout::SafeHtml;
@@ -99,26 +99,16 @@ pub fn pod_layout() -> Html {
                                 </div>
                             }
                         } else {
-                            html! {
-                                <>
-                                    <div class="empty-episodes-container">
-                                        <img src="static/assets/favicon.png" alt="Logo" class="logo"/>
-                                        <h1>{ "No Podcast Search Results Found" }</h1>
-                                        <p>{"Try searching again with a different set of keywords."}</p>
-                                    </div>
-                                </>
-                            }
+                            empty_message(
+                                "No Podcast Search Results Found",
+                                "Try searching again with a different set of keywords."
+                            )
                         }
                     } else {
-                        html! {
-                            <>
-                                <div class="empty-episodes-container">
-                                    <img src="static/assets/favicon.png" alt="Logo" class="logo"/>
-                                    <h1>{ "No Podcast Search Results Found" }</h1>
-                                    <p>{"Try searching again with a different set of keywords."}</p>
-                                </div>
-                            </>
-                        }
+                        empty_message(
+                            "No Podcast Search Results Found",
+                            "Try searching again with a different set of keywords."
+                        )
                     }
                 }
                 <App_drawer />

--- a/web/src/requests/search_pods.rs
+++ b/web/src/requests/search_pods.rs
@@ -1,3 +1,4 @@
+use crate::components::podcast_layout::ClickedFeedURL;
 use anyhow::Error;
 use chrono::DateTime;
 use gloo_net::http::Request;
@@ -486,6 +487,41 @@ pub async fn call_parse_podcast_channel_info(podcast_url: &str) -> Result<Podcas
     };
 
     Ok(podcast_info)
+}
+
+pub async fn call_get_podcast_details_dynamic(
+    server_name: &str,
+    api_key: &str,
+    user_id: i32,
+    podcast_title: &str,
+    podcast_url: &str,
+    added: bool,
+) -> Result<ClickedFeedURL, Error> {
+    let url = format!(
+        "{}/api/data/get_podcast_details_dynamic?user_id={}&podcast_title={}&podcast_url={}&added={}",
+        server_name, user_id, podcast_title, podcast_url, added
+    );
+
+    let response = Request::get(&url)
+        .header("Content-Type", "application/json")
+        .header("Api-Key", api_key)
+        .send()
+        .await
+        .map_err(|e| Error::msg(format!("Network request error: {}", e)))?;
+
+    if response.ok() {
+        let podcast_details: ClickedFeedURL = response
+            .json()
+            .await
+            .map_err(|e| Error::msg(format!("Failed to parse response: {}", e)))?;
+
+        Ok(podcast_details)
+    } else {
+        Err(Error::msg(format!(
+            "Error retrieving podcast details. Server response: {}",
+            response.status_text()
+        )))
+    }
 }
 
 // In Databases


### PR DESCRIPTION
episode_layout now utilizes the url to support information and data for the podcast. Whether they are added to the db or not it works great, and you can share a link with others on the same server. They look like this: 

http://localhost:8080/episode_layout?podcast_title=Ship%20It%21%20SRE%2C%20Platform%20Engineering%2C%20DevOps&podcast_url=https%3A%2F%2Fchangelog.com%2Fshipit%2Ffeed