### PR TITLE
Increment ep count during episode addition

### DIFF
--- a/database_functions/app_functions.py
+++ b/database_functions/app_functions.py
@@ -121,7 +121,7 @@ def get_podcast_values(feed_url, user_id):
         'pod_author': d.feed.author if hasattr(d.feed, 'author') else None,
         'categories': [],
         'pod_description': d.feed.description if hasattr(d.feed, 'description') else None,
-        'pod_episode_count': len(d.entries),
+        'pod_episode_count': 0,
         'pod_feed_url': feed_url,
         'pod_website': d.feed.link if hasattr(d.feed, 'link') else None,
         'pod_explicit': False,


### PR DESCRIPTION
We now increment episode counts in the db during addition. This ensures the count is accurate as podcasts continue to refresh over time. 