### PR TITLE
Added home button component for quick access

### DIFF
--- a/completed_todos.md
+++ b/completed_todos.md
@@ -29,6 +29,7 @@ Version 0.6.4
 - [x] Fixed issue with user stats page where it would lose user context on reload #135
 - [x] Fixed issue with settings page where it would lose user context on reload #134
 - [x] Fixed issue with episode_layout page where it would lose user context on reload and also made podcasts sharable via link #213
+- [x] Fixed issue where podcast episode counts wouldn't increment after initial add to the db
 - [x] Ugraded gloo::net to 0.6.0
 - [x] Upgraded openssl in src-tauri to 0.10.66
 - [x] Upgraded a few other rust depends to next minor version

--- a/web/src/components/app_drawer.rs
+++ b/web/src/components/app_drawer.rs
@@ -3,6 +3,7 @@ use crate::components::context::AppState;
 use yew::prelude::*;
 use yew_router::prelude::Link;
 use yewdux::use_store;
+use web_sys::window;
 
 #[allow(non_camel_case_types)]
 #[function_component(App_drawer)]
@@ -30,6 +31,14 @@ pub fn app_drawer() -> Html {
             }
         }
     };
+
+    let current_path = window()
+    .unwrap()
+    .location()
+    .pathname()
+    .unwrap_or_else(|_| String::new());
+
+    let show_home_button = current_path != "/home";
 
     #[cfg(not(feature = "server_build"))]
     let local_download_link = html! {
@@ -166,28 +175,38 @@ pub fn app_drawer() -> Html {
                     <div class="w-6 h-1 drawer-burger rounded-lg"></div>
                 </div>
             </label>
-
-        <div class="w-8 h-8 ml-3">
-
-            {
-                match state.is_loading {
-                    Some(true) => html! {
-                        // <div class="spinner-border animate-spin inline-block w-8 h-8 border-4 custom-spinner-color rounded-full" role="status">
-                        //     <span class="visually-hidden">{""}</span>
-                        // </div>
-                        <div role="status">
-                            <svg aria-hidden="true" class="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
-                                <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
-                            </svg>
-                            <span class="sr-only">{"Loading..."}</span>
-                        </div>
-                    },
-                    _ => html! {}, // Covers both Some(false) and None
+        
+            <div class="w-8 h-8 ml-3 flex items-center">
+        
+                { if show_home_button {
+                    html! {
+                        <Link<Route> to={Route::Home} classes="rounded-lg cursor-pointer">
+                            <div class="flex flex-col items-center">
+                                <span class="home-material-icons material-icons">{ "home" }</span>
+                            </div>
+                        </Link<Route>>
+                    }
+                } else {
+                    html! {}
+                }}
+        
+                {
+                    match state.is_loading {
+                        Some(true) => html! {
+                            <div role="status" class="ml-3">
+                                <svg aria-hidden="true" class="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
+                                    <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
+                                </svg>
+                                <span class="sr-only">{"Loading..."}</span>
+                            </div>
+                        },
+                        _ => html! {}, // Covers both Some(false) and None
+                    }
                 }
-            }
+            </div>
         </div>
-        </div>
+        
 
 
             // <input

--- a/web/src/components/episodes_layout.rs
+++ b/web/src/components/episodes_layout.rs
@@ -73,6 +73,12 @@ fn download_icon() -> Html {
 
     }
 }
+fn home_icon() -> Html {
+    html! {
+        <span class="material-icons">{ "home" }</span>
+
+    }
+}
 fn no_icon() -> Html {
     html! {}
 }

--- a/web/src/components/episodes_layout.rs
+++ b/web/src/components/episodes_layout.rs
@@ -73,12 +73,6 @@ fn download_icon() -> Html {
 
     }
 }
-fn home_icon() -> Html {
-    html! {
-        <span class="material-icons">{ "home" }</span>
-
-    }
-}
 fn no_icon() -> Html {
     html! {}
 }

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1494,6 +1494,13 @@ button.item-container-action-button.item-container-action-button {
     /* Or whatever size you prefer */
 }
 
+.home-material-icons {
+    width: 30px;
+    height: 35px;
+    font-size: 33px !important;
+    /* Or whatever size you prefer */
+}
+
 .icon-space {
     transform: translateY(4px);
     margin-right: 10px;


### PR DESCRIPTION
This adds a home button next to the app drawer when not on the home page directly. This allows for quick access to return from any page. Without opening the app drawer itself. 