### PR TITLE
Added confirmation dialog when removing pod

### DIFF
--- a/clients/clientapi.py
+++ b/clients/clientapi.py
@@ -2226,14 +2226,17 @@ async def api_delete_api_key(payload: DeleteAPIKeyHeaders, cnx=Depends(get_datab
     if database_functions.functions.is_same_api_key(cnx, database_type, payload.api_id, api_key):
         raise HTTPException(status_code=403,
                             detail="You cannot delete the API key that is currently in use.")
-
+    print('same done')
     # Check if the API key belongs to the guest user (user_id 1)
     if database_functions.functions.belongs_to_guest_user(cnx, database_type, payload.api_id):
         raise HTTPException(status_code=403,
                             detail="Cannot delete guest user api.")
+    print('belongs done')
 
     # Proceed with deletion if the checks pass
+    print('deleting')
     database_functions.functions.delete_api(cnx, database_type, payload.api_id)
+    print('deleted')
     return {"detail": "API key deleted."}
 
 

--- a/completed_todos.md
+++ b/completed_todos.md
@@ -13,10 +13,16 @@ Next Minor Version:
 - [] Push completion status to Nextcloud/gpodder
 - [] Test with LXC containers
 - [] Queue adjmustment for mobile devices
+- [] Adjust download checkboxes to look nicer
+- [] Change download multiple buttons to be on same line as header
 - [] Full Show deletion with checkbox on download page
 - [] Added a People page so that you can see other episodes and podcasts a particular person has been on
 - [] Manually adjust tags for podcast in podcast settings
 - [] Update Feed directly after adding a Nextcloud/gpodder sync server instead of waiting for the next refresh
+- [] Update api key creation and deletion after change dynamically with use_effect
+- [] Update mfa setup slider after setup dynamically with use_effect
+- [] Known timezone issue in add_episode - pinepods-1  | /opt/venv/lib/python3.11/site-packages/dateutil/parser/_parser.py:1207: UnknownTimezoneWarning: tzname EDT identified but not understood.  Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.  In a future version, this will raise an exception.
+pinepods-1  |   warnings.warn("tzname {tzname} identified but not understood.  "
 
 Version 0.6.4
 
@@ -33,6 +39,14 @@ Version 0.6.4
 - [x] Ugraded gloo::net to 0.6.0
 - [x] Upgraded openssl in src-tauri to 0.10.66
 - [x] Upgraded a few other rust depends to next minor version
+- [x] Added loading spinner to custom feed and implemented more clear success message
+- [x] Fixed postgres return issue on user_stats route
+- [x] Fixed postgres return issue on mfa return route
+- [] Fixed delete api key route for postgres
+- [] Implemented adjustment on all modals throughout the app so clicking outside them closes them (episode layout confiramtions missing yet - also test all login modals)
+- [] Implemented adjustment on all modals so that they overlap everything in the app (This was causing issues on small screens)
+- [] Added Confirmation dialog modal to podcast deletion on /podcasts layout page
+- [] Changed name of bt user to background_tasks to make the user more clear on api key settings display
 
 Version 0.6.3
 

--- a/web/src/components/episodes_layout.rs
+++ b/web/src/components/episodes_layout.rs
@@ -917,6 +917,21 @@ pub fn episode_layout() -> Html {
         })
     };
 
+    let on_background_click = {
+        let on_close_modal = on_close_modal.clone();
+        Callback::from(move |e: MouseEvent| {
+            let target = e.target().unwrap();
+            let element = target.dyn_into::<web_sys::Element>().unwrap();
+            if element.tag_name() == "DIV" {
+                on_close_modal.emit(e);
+            }
+        })
+    };
+
+    let stop_propagation = Callback::from(|e: MouseEvent| {
+        e.stop_propagation();
+    });
+
     let toggle_download = {
         let api_key = api_key.clone();
         let server_name = server_name.clone();
@@ -1021,8 +1036,8 @@ pub fn episode_layout() -> Html {
 
     // Define the modal components
     let podcast_option_model = html! {
-        <div id="podcast_option_model" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="podcast_option_model" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">
@@ -1094,8 +1109,8 @@ pub fn episode_layout() -> Html {
 
     // Define the modal components
     let download_all_model = html! {
-        <div id="download_all_modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="download_all_modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">
@@ -1130,8 +1145,8 @@ pub fn episode_layout() -> Html {
 
     // Define the modal components
     let delete_pod_model = html! {
-        <div id="delete_pod_model" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="delete_pod_model" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">

--- a/web/src/components/login.rs
+++ b/web/src/components/login.rs
@@ -527,6 +527,22 @@ pub fn login() -> Html {
         })
     };
 
+    let on_background_click = {
+        let on_close_modal = on_close_modal.clone();
+        Callback::from(move |e: MouseEvent| {
+            let target = e.target().unwrap();
+            let element = target.dyn_into::<web_sys::Element>().unwrap();
+            if element.tag_name() == "DIV" {
+                on_close_modal.emit(e);
+            }
+        })
+    };
+
+    let stop_propagation = Callback::from(|e: MouseEvent| {
+        e.stop_propagation();
+    });
+
+
     let on_fullname_change = {
         let fullname = fullname.clone();
         Callback::from(move |e: InputEvent| {
@@ -680,8 +696,8 @@ pub fn login() -> Html {
     };
     // Define the modal components
     let create_user_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">
@@ -812,8 +828,8 @@ pub fn login() -> Html {
     };
 
     let forgot_password_modal = html! {
-        <div id="forgot-password-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="forgot-password-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">
@@ -929,8 +945,8 @@ pub fn login() -> Html {
     };
 
     let enter_code_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">
@@ -1096,12 +1112,6 @@ pub fn login() -> Html {
                         <h3 class="text-xl font-semibold">
                             {"Time Zone Setup"}
                         </h3>
-                        <button onclick={on_close_modal.clone()} class="end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">
-                            <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-                            </svg>
-                            <span class="sr-only">{"Close modal"}</span>
-                        </button>
                     </div>
                     <div class="p-4 md:p-5">
                         <form class="space-y-4" action="#">
@@ -1251,8 +1261,8 @@ pub fn login() -> Html {
     };
 
     let mfa_code_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="relative p-4 w-full max-w-md max-h-full bg-white rounded-lg shadow dark:bg-gray-700">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="relative p-4 w-full max-w-md max-h-full bg-white rounded-lg shadow dark:bg-gray-700" onclick={stop_propagation.clone()}>
                 <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
@@ -1674,6 +1684,21 @@ pub fn login() -> Html {
         })
     };
 
+    let on_background_click = {
+        let on_close_modal = on_close_modal.clone();
+        Callback::from(move |e: MouseEvent| {
+            let target = e.target().unwrap();
+            let element = target.dyn_into::<web_sys::Element>().unwrap();
+            if element.tag_name() == "DIV" {
+                on_close_modal.emit(e);
+            }
+        })
+    };
+
+    let stop_propagation = Callback::from(|e: MouseEvent| {
+        e.stop_propagation();
+    });
+
     let on_tz_change = {
         let tz = time_zone.clone();
         Callback::from(move |e: InputEvent| {
@@ -1801,12 +1826,6 @@ pub fn login() -> Html {
                         <h3 class="text-xl font-semibold">
                             {"Time Zone Setup"}
                         </h3>
-                        <button onclick={on_close_modal.clone()} class="end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">
-                            <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-                            </svg>
-                            <span class="sr-only">{"Close modal"}</span>
-                        </button>
                     </div>
                     <div class="p-4 md:p-5">
                         <form class="space-y-4" action="#">
@@ -1960,8 +1979,8 @@ pub fn login() -> Html {
     };
 
     let mfa_code_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="relative p-4 w-full max-w-md max-h-full bg-white rounded-lg shadow dark:bg-gray-700">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="relative p-4 w-full max-w-md max-h-full bg-white rounded-lg shadow dark:bg-gray-700" onclick={stop_propagation.clone()}>
                 <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white">

--- a/web/src/components/podcast_layout.rs
+++ b/web/src/components/podcast_layout.rs
@@ -463,7 +463,7 @@ pub fn podcast_item(props: &PodcastProps) -> Html {
                             // <p class="item_container-text">{ &podcast.description }</p>
                             {
                                 html! {
-                                    <div class="item-container-text hidden md:block">
+                                    <div class="item-description-text hidden md:block">
                                         <div class={format!("item_container-text episode-description-container {}", description_class)}>
                                             <SafeHtml html={podcast_description_clone} />
                                         </div>

--- a/web/src/components/setting_components/api_keys.rs
+++ b/web/src/components/setting_components/api_keys.rs
@@ -3,6 +3,7 @@ use yewdux::prelude::*;
 use crate::components::context::{AppState, UIState};
 use crate::requests::setting_reqs::{call_get_api_info, call_create_api_key, call_delete_api_key, DeleteAPIRequest};
 // use crate::gen_components::_ErrorMessageProps::error_message;
+use wasm_bindgen::JsCast;
 
 #[function_component(APIKeys)]
 pub fn api_keys() -> Html {
@@ -74,6 +75,22 @@ pub fn api_keys() -> Html {
             page_state.set(PageState::Hidden);
         })
     };
+
+    let on_background_click = {
+        let on_close_modal = close_modal.clone();
+        Callback::from(move |e: MouseEvent| {
+            let target = e.target().unwrap();
+            let element = target.dyn_into::<web_sys::Element>().unwrap();
+            if element.tag_name() == "DIV" {
+                on_close_modal.emit(e);
+            }
+        })
+    };
+
+    let stop_propagation = Callback::from(|e: MouseEvent| {
+        e.stop_propagation();
+    });
+
 
     // Define the function to open the modal and request a new API key
     let request_state = state.clone();
@@ -151,8 +168,8 @@ pub fn api_keys() -> Html {
 
 
     let delete_api_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="relative rounded-lg shadow">
                     <div class="flex flex-col items-start justify-between p-4 md:p-5 border-b rounded-t">
                         <button onclick={close_modal.clone()} class="self-end text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">
@@ -182,29 +199,27 @@ pub fn api_keys() -> Html {
     };
 
     let create_api_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="relative p-4 w-full max-w-md max-h-full bg-white rounded-lg shadow dark:bg-gray-700">
-                <div class="modal-container relative rounded-lg shadow">
-                    <div class="flex flex-col items-start justify-between p-4 md:p-5 border-b rounded-t ">
-                        <button onclick={close_modal.clone()} class="end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">
-                            <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-                            </svg>
-                            <span class="sr-only">{"Close modal"}</span>
-                        </button>
-                        <h3 class="item_container-text text-xl font-semibold">
-                            {"New Api Key Created"}
-                        </h3>
-                        <p class="text-m font-semibold item_container-text">
-                        {"Copy the API Key Listed Below. Be sure to save it in a safe place. You will only ever be able to view it once. You can always just create a new one if you lose it."}
-                        </p>
-                        <div class="mfa-code-box mt-4 p-4 rounded-md overflow-x-auto whitespace-nowrap max-w-full">
-                            {api_key_display}
-                        </div>
-                        <button onclick={close_modal.clone()} class="mt-4 download-button font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
-                            {"OK"}
-                        </button>
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
+                <div class="flex flex-col items-start justify-between p-4 md:p-5 border-b rounded-t ">
+                    <button onclick={close_modal.clone()} class="end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">
+                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+                        </svg>
+                        <span class="sr-only">{"Close modal"}</span>
+                    </button>
+                    <h3 class="item_container-text text-xl font-semibold">
+                        {"New Api Key Created"}
+                    </h3>
+                    <p class="text-m font-semibold item_container-text">
+                    {"Copy the API Key Listed Below. Be sure to save it in a safe place. You will only ever be able to view it once. You can always just create a new one if you lose it."}
+                    </p>
+                    <div class="mfa-code-box mt-4 p-4 rounded-md overflow-x-auto whitespace-nowrap max-w-full">
+                        {api_key_display}
                     </div>
+                    <button onclick={close_modal.clone()} class="mt-4 download-button font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+                        {"OK"}
+                    </button>
                 </div>
             </div>
         </div>

--- a/web/src/components/setting_components/mfa_settings.rs
+++ b/web/src/components/setting_components/mfa_settings.rs
@@ -7,6 +7,7 @@ use std::borrow::Borrow;
 use yew::platform::spawn_local;
 use yew::prelude::*;
 use yewdux::prelude::*;
+use wasm_bindgen::JsCast;
 
 #[function_component(MFAOptions)]
 pub fn mfa_options() -> Html {
@@ -78,6 +79,21 @@ pub fn mfa_options() -> Html {
             page_state.set(PageState::Hidden);
         })
     };
+
+    let on_background_click = {
+        let on_close_modal = close_modal.clone();
+        Callback::from(move |e: MouseEvent| {
+            let target = e.target().unwrap();
+            let element = target.dyn_into::<web_sys::Element>().unwrap();
+            if element.tag_name() == "DIV" {
+                on_close_modal.emit(e);
+            }
+        })
+    };
+
+    let stop_propagation = Callback::from(|e: MouseEvent| {
+        e.stop_propagation();
+    });
 
     let open_setup_modal = {
         let mfa_code = mfa_code.clone();
@@ -204,8 +220,8 @@ pub fn mfa_options() -> Html {
     // let svg_data_url = format!("data:image/svg+xml;utf8,{}", url_encode(&(*mfa_code).clone()));
     let qr_code_svg = (*mfa_code).clone();
     let setup_mfa_modal = html! {
-        <div id="setup-mfa-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="setup-mfa-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex flex-col items-start justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
                         <button onclick={close_modal.clone()} class="self-end text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">

--- a/web/src/components/setting_components/user_settings.rs
+++ b/web/src/components/setting_components/user_settings.rs
@@ -8,6 +8,7 @@ use std::borrow::Borrow;
 use crate::requests::setting_reqs::{SettingsUser, call_add_user, call_delete_user, AddSettingsUserRequest, call_set_password, call_set_email, call_set_fullname, call_set_username, call_check_admin, call_set_isadmin};
 use crate::components::gen_funcs::{ValidationError, encode_password, validate_email, validate_username};
 use crate::components::gen_funcs::validate_user_input;
+use wasm_bindgen::JsCast;
 // use crate::gen_components::_ErrorMessageProps::error_message;
 
 
@@ -99,14 +100,27 @@ pub fn user_settings() -> Html {
     // Define the initial state
     let page_state = use_state(|| PageState::Hidden);
 
-
-    // Define the callback function for closing the modal
     let on_close_modal = {
         let page_state = page_state.clone();
-        Callback::from(move |_| {
+        Callback::from(move |_: MouseEvent| {
             page_state.set(PageState::Hidden);
         })
     };
+
+    let on_background_click = {
+        let on_close_modal = on_close_modal.clone();
+        Callback::from(move |e: MouseEvent| {
+            let target = e.target().unwrap();
+            let element = target.dyn_into::<web_sys::Element>().unwrap();
+            if element.tag_name() == "DIV" {
+                on_close_modal.emit(e);
+            }
+        })
+    };
+
+    let stop_propagation = Callback::from(|e: MouseEvent| {
+        e.stop_propagation();
+    });
 
     // Define the callback functions
     let on_create_new_user = {
@@ -239,8 +253,8 @@ pub fn user_settings() -> Html {
 
     // Define the modal components
     let create_user_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">
@@ -296,6 +310,7 @@ pub fn user_settings() -> Html {
             </div>
         </div>
     };
+
     let user_dispatch = ui_user.clone();
     let edit_admin_call = admin_edit_status.clone();
     let on_user_row_click = {
@@ -670,10 +685,11 @@ pub fn user_settings() -> Html {
             // Handle admin status change if applicable
         })
     };
+
     // Define the modal components
     let edit_user_modal = html! {
-        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25">
-            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow">
+        <div id="create-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-25" onclick={on_background_click.clone()}>
+            <div class="modal-container relative p-4 w-full max-w-md max-h-full rounded-lg shadow z-50" onclick={stop_propagation.clone()}>
                 <div class="modal-container relative rounded-lg shadow">
                     <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t">
                         <h3 class="text-xl font-semibold">

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -193,7 +193,7 @@ body {
     /* Align to the left of the viewport */
     right: 0;
     /* Ensure it extends to the right of the viewport */
-    z-index: 1000;
+    z-index: 49;
     /* Make sure it stays on top of other content */
 }
 


### PR DESCRIPTION
Implemented a dialog when removing podcasts on the podcast layout page at /podcasts.

Also added a few additional escape options to the modals. Clicking outside a modal anywhere closes them, additionally, they now overlap everything on screen. Including the app bar. Which was preventing closing them on small screens.