### PR TITLE
Fix name of valkey service in chart

### DIFF
--- a/deployment/kubernetes/helm/pinepods/templates/_helpers.tpl
+++ b/deployment/kubernetes/helm/pinepods/templates/_helpers.tpl
@@ -20,7 +20,7 @@
 {{- end }}
 
 {{- define "pinepods.valkey.fullname" -}}
-{{- printf "%s-valkey" (include "pinepods.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-valkey-primary" (include "pinepods.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- define "pinepods.labels" -}}


### PR DESCRIPTION
The format for this name didn't match the names that the valgrind service had on my end so this didn't work.