### PR TITLE
Fix externalDatabase values not being used in chart & more

### DIFF
--- a/deployment/kubernetes/helm/pinepods/templates/deployment.yaml
+++ b/deployment/kubernetes/helm/pinepods/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "pinepods.fullname" $ }}-env
+          env:
+            {{ if (and (not .Values.postgresql.enabled) (.Values.externalDatabase.existingSecret.enabled)) -}}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.existingSecret.name }}
+                  key: {{ .Values.externalDatabase.existingSecret.key }}
+            {{- end }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: downloads

--- a/deployment/kubernetes/helm/pinepods/templates/deployment.yaml
+++ b/deployment/kubernetes/helm/pinepods/templates/deployment.yaml
@@ -28,13 +28,6 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "pinepods.fullname" $ }}-env
-          env:
-            - name: DB_HOST
-              value: {{ include "pinepods.postgresql.fullname" . }}
-            - name: VALKEY_HOST
-              value: {{ include "pinepods.valkey.fullname" . }}
-            - name: VALKEY_PORT
-              value: "{{ .Values.valkey.service.port }}"
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: downloads

--- a/deployment/kubernetes/helm/pinepods/templates/secret.yaml
+++ b/deployment/kubernetes/helm/pinepods/templates/secret.yaml
@@ -1,6 +1,22 @@
 {{- /* Set default environment variables. */ -}}
 {{ $env := dict -}}
-{{ $_ := set $env "DB_HOST" (include "pinepods.postgresql.fullname" .) }}
+
+{{ if .Values.postgresql.enabled }}
+  {{ $_ := set $env "DB_TYPE" "postgresql" }}
+  {{ $_ := set $env "DB_HOST" (include "pinepods.postgresql.fullname" .) }}
+  {{ $_ := set $env "DB_PORT" "5432" }}
+  {{ $_ := set $env "DB_NAME" "pinepods_database" }}
+  {{ $_ := set $env "DB_USER" "postgres" }}
+  {{ $_ := set $env "DB_PASSWORD" .Values.postgresql.auth.password }}
+{{ else }}
+  {{ $_ := set $env "DB_TYPE" .Values.externalDatabase.type }}
+  {{ $_ := set $env "DB_HOST" .Values.externalDatabase.host }}
+  {{ $_ := set $env "DB_PORT" .Values.externalDatabase.port }}
+  {{ $_ := set $env "DB_NAME" .Values.externalDatabase.database }}
+  {{ $_ := set $env "DB_USER" .Values.externalDatabase.user }}
+  {{ $_ := set $env "DB_PASSWORD" .Values.externalDatabase.password }}
+{{ end -}}
+
 {{ $_ := set $env "VALKEY_HOST" (include "pinepods.valkey.fullname" .) }}
 {{ $_ := set $env "VALKEY_PORT" (.Values.valkey.service.port) }}
 
@@ -18,4 +34,3 @@ stringData:
   {{- range $key, $value := $env }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
-  DB_PASSWORD: {{ .Values.postgresql.auth.password | quote }}

--- a/deployment/kubernetes/helm/pinepods/templates/secret.yaml
+++ b/deployment/kubernetes/helm/pinepods/templates/secret.yaml
@@ -14,7 +14,9 @@
   {{ $_ := set $env "DB_PORT" .Values.externalDatabase.port }}
   {{ $_ := set $env "DB_NAME" .Values.externalDatabase.database }}
   {{ $_ := set $env "DB_USER" .Values.externalDatabase.user }}
-  {{ $_ := set $env "DB_PASSWORD" .Values.externalDatabase.password }}
+  {{ if not .Values.externalDatabase.existingSecret.enabled -}}
+    {{ $_ := set $env "DB_PASSWORD" .Values.externalDatabase.password }}
+  {{ end -}}
 {{ end -}}
 
 {{ if .Values.valkey.enabled }}

--- a/deployment/kubernetes/helm/pinepods/templates/secret.yaml
+++ b/deployment/kubernetes/helm/pinepods/templates/secret.yaml
@@ -1,3 +1,12 @@
+{{- /* Set default environment variables. */ -}}
+{{ $env := dict -}}
+{{ $_ := set $env "DB_HOST" (include "pinepods.postgresql.fullname" .) }}
+{{ $_ := set $env "VALKEY_HOST" (include "pinepods.valkey.fullname" .) }}
+{{ $_ := set $env "VALKEY_PORT" (.Values.valkey.service.port) }}
+
+{{- /* Merge in user-specified environment variables, overriding the above. */ -}}
+{{ $env := mergeOverwrite $env .Values.env -}}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,7 +15,7 @@ metadata:
     {{- include "pinepods.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- range $key, $value := .Values.env }}
+  {{- range $key, $value := $env }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
   DB_PASSWORD: {{ .Values.postgresql.auth.password | quote }}

--- a/deployment/kubernetes/helm/pinepods/templates/secret.yaml
+++ b/deployment/kubernetes/helm/pinepods/templates/secret.yaml
@@ -17,8 +17,10 @@
   {{ $_ := set $env "DB_PASSWORD" .Values.externalDatabase.password }}
 {{ end -}}
 
-{{ $_ := set $env "VALKEY_HOST" (include "pinepods.valkey.fullname" .) }}
-{{ $_ := set $env "VALKEY_PORT" (.Values.valkey.service.port) }}
+{{ if .Values.valkey.enabled }}
+  {{ $_ := set $env "VALKEY_HOST" (include "pinepods.valkey.fullname" .) }}
+  {{ $_ := set $env "VALKEY_PORT" (.Values.valkey.service.port) }}
+{{ end -}}
 
 {{- /* Merge in user-specified environment variables, overriding the above. */ -}}
 {{ $env := mergeOverwrite $env .Values.env -}}

--- a/deployment/kubernetes/helm/pinepods/values.yaml
+++ b/deployment/kubernetes/helm/pinepods/values.yaml
@@ -112,6 +112,10 @@ externalDatabase:
   user: postgres
   password: ""
   database: pinepods_database
+  existingSecret:
+    enabled: false
+    name: existing-secret
+    key: password
 
 resources: {}
 

--- a/deployment/kubernetes/helm/pinepods/values.yaml
+++ b/deployment/kubernetes/helm/pinepods/values.yaml
@@ -147,18 +147,6 @@ env:
   # -- Admin email address
   EMAIL: "admin@example.com"
   
-  # Database Configuration
-  # -- Database type (postgresql only for now)
-  DB_TYPE: "postgresql"
-  # -- Database user
-  # This should match postgresql.auth.username if using included PostgreSQL
-  DB_USER: "postgres"
-  # -- Database name
-  # This should match postgresql.auth.database if using included PostgreSQL
-  DB_NAME: "pinepods_database"
-  # -- Database port
-  DB_PORT: "5432"
-  
   # Valkey Configuration
   # -- Valkey host
   # This is automatically set in deployment template - do not change


### PR DESCRIPTION
This is a reworked version of #540. While rebasing this PR I realized that it would be much less verbose to set all the `DB_*` envs in the secret instead of in the deployment so I did that instead.

Question: if I have more chart improvements would you prefer multiple smaller & more specific PRs like I've been doing, or a single larger PR combining all changes?