### PR TITLE
Implement settings for OIDC claims & roles

### DIFF
--- a/clients/clientapi.py
+++ b/clients/clientapi.py
@@ -3586,6 +3586,12 @@ class OIDCProviderValues(BaseModel):
     button_color: Optional[str] = "#000000"
     button_text_color: Optional[str] = "#000000"
     icon_svg: Optional[str] = None
+    name_claim: Optional[str] = None
+    email_claim: Optional[str] = None
+    username_claim: Optional[str] = None
+    roles_claim: Optional[str] = None
+    user_role: Optional[str] = None
+    admin_role: Optional[str] = None
 
 @app.post("/api/data/add_oidc_provider")
 async def api_add_oidc_provider(
@@ -3605,7 +3611,13 @@ async def api_add_oidc_provider(
             provider_values.scope,
             provider_values.button_color,
             provider_values.button_text_color,
-            provider_values.icon_svg
+            provider_values.icon_svg,
+            provider_values.name_claim,
+            provider_values.email_claim,
+            provider_values.username_claim,
+            provider_values.roles_claim,
+            provider_values.user_role,
+            provider_values.admin_role
         ))
         if not provider_id:
             raise HTTPException(
@@ -6434,7 +6446,7 @@ async def oidc_callback(
             )
 
         # Unpack provider details
-        provider_id, client_id, client_secret, token_url, userinfo_url = provider
+        provider_id, client_id, client_secret, token_url, userinfo_url, name_claim, email_claim, username_claim, roles_claim, user_role, admin_role = provider
 
         # Exchange authorization code for access token
         async with httpx.AsyncClient() as client:
@@ -6479,7 +6491,7 @@ async def oidc_callback(
 
                 user_info = userinfo_response.json()
                 print(f"User info response: {user_info}")
-                email = user_info.get("email")
+                email = user_info.get(email_claim or "email")
 
                 parsed_url = urlparse(userinfo_url)
                 if not email and parsed_url.hostname == 'api.github.com':
@@ -6515,23 +6527,87 @@ async def oidc_callback(
                     url=f"{frontend_base}/oauth/callback?error=network_error"
                 )
 
+            # Verify access.
+            if roles_claim and user_role:
+                roles = user_info.get(roles_claim)
+                if not isinstance(roles, list):
+                    print(f'Claim {roles_claim} should be a list of strings, but it is {roles}.')
+                    return RedirectResponse(
+                        url=f"{frontend_base}/oauth/callback?error=no_access&details=invalid_roles"
+                    )
+                if user_role not in roles and not (admin_role and admin_role in roles):
+                    print(f"User user role {user_role} {f'and admin role {admin_role}' if admin_role else ''} not in user's roles ({roles}), denying access.")
+                    return RedirectResponse(
+                        url=f"{frontend_base}/oauth/callback?error=no_access"
+                    )
+
             # Check if user exists
             user = database_functions.functions.get_user_by_email(cnx, database_type, email)
 
             # In your OIDC callback function, replace the user creation section with:
 
+            # Determine the user's information
+            fullname = user_info.get(name_claim or "name", "")
+            if username_claim and username_claim not in user_info:
+                print(f"Unable to determine username for user, username claim {username_claim} not present")
+                return RedirectResponse(
+                    url=f"{frontend_base}/oauth/callback?error=user_creation_failed&details=username_claim_missing"
+                )
+            username = user_info.get(username_claim or "preferred_username")
+
             if not user:
                 # Create new user
                 print(f"User with email {email} not found, creating new user")
-                fullname = user_info.get("name", "")
-                username = email.split("@")[0].lower()
-                base_username = username
-                counter = 1
-                max_attempts = 10
 
-                while counter <= max_attempts:
+                if username is None:
+                    username = email.split("@")[0].lower()
+                    base_username = username
+                    counter = 1
+                    max_attempts = 10
+
+                    while counter <= max_attempts:
+                        try:
+                            print(f"Attempt {counter} to create user with base username: {base_username}")
+                            user_id = database_functions.functions.create_oidc_user(
+                                cnx, database_type, email, fullname, username
+                            )
+                            print(f"User created successfully with ID: {user_id}")
+
+                            if not user_id:
+                                print(f"ERROR: Invalid user_id returned: {user_id}")
+                                return RedirectResponse(
+                                    url=f"{frontend_base}/oauth/callback?error=invalid_user_id"
+                                )
+
+                            print(f"Creating API key for user_id: {user_id}")
+                            api_key = database_functions.functions.create_api_key(cnx, database_type, user_id)
+                            print(f"API key created: {api_key[:5]}... (truncated for security)")
+                            break
+                        except UniqueViolation:
+                            print(f"Username conflict with {username}, trying next variation")
+                            username = f"{base_username}{counter}"
+                            counter += 1
+                            if counter > max_attempts:
+                                print(f"Failed to create user after {max_attempts} attempts due to username conflicts")
+                                return RedirectResponse(
+                                    url=f"{frontend_base}/oauth/callback?error=username_conflict"
+                                )
+                        except Exception as e:
+                            print(f"Error during user creation: {str(e)}")
+                            import traceback
+                            print(f"Traceback: {traceback.format_exc()}")
+                            return RedirectResponse(
+                                url=f"{frontend_base}/oauth/callback?error=user_creation_failed&details={str(e)[:50]}"
+                            )
+                    else:
+                        print("Failed to create user after maximum attempts")
+                        return RedirectResponse(
+                            url=f"{frontend_base}/oauth/callback?error=user_creation_failed"
+                        )
+
+                else:
                     try:
-                        print(f"Attempt {counter} to create user with base username: {base_username}")
+                        print(f"Attempt to create user with username: {username}")
                         user_id = database_functions.functions.create_oidc_user(
                             cnx, database_type, email, fullname, username
                         )
@@ -6546,16 +6622,11 @@ async def oidc_callback(
                         print(f"Creating API key for user_id: {user_id}")
                         api_key = database_functions.functions.create_api_key(cnx, database_type, user_id)
                         print(f"API key created: {api_key[:5]}... (truncated for security)")
-                        break
                     except UniqueViolation:
-                        print(f"Username conflict with {username}, trying next variation")
-                        username = f"{base_username}{counter}"
-                        counter += 1
-                        if counter > max_attempts:
-                            print(f"Failed to create user after {max_attempts} attempts due to username conflicts")
-                            return RedirectResponse(
-                                url=f"{frontend_base}/oauth/callback?error=username_conflict"
-                            )
+                        print("Failed to create user due to username conflicts")
+                        return RedirectResponse(
+                            url=f"{frontend_base}/oauth/callback?error=username_conflict"
+                        )
                     except Exception as e:
                         print(f"Error during user creation: {str(e)}")
                         import traceback
@@ -6563,11 +6634,6 @@ async def oidc_callback(
                         return RedirectResponse(
                             url=f"{frontend_base}/oauth/callback?error=user_creation_failed&details={str(e)[:50]}"
                         )
-                else:
-                    print("Failed to create user after maximum attempts")
-                    return RedirectResponse(
-                        url=f"{frontend_base}/oauth/callback?error=user_creation_failed"
-                    )
 
             else:
                 # Existing user - retrieve their API key
@@ -6580,6 +6646,26 @@ async def oidc_callback(
                     api_key = database_functions.functions.create_api_key(cnx, database_type, user_id)
 
                 print(f"API key retrieved: {api_key[:5]}... (truncated for security)")
+
+                # Update user info based on OIDC information.
+                database_functions.functions.set_fullname(cnx, database_type, user_id, fullname)
+
+                current_username = user[2] if isinstance(user, tuple) else user['username']
+                if username_claim and username != current_username:
+                    if database_functions.functions.check_usernames(cnx, database_type, username):
+                        print(f'Unable to update username for user {user_id} to match the username specified by the OIDC provider ({username}) as this is already in use by another user.')
+                    else:
+                        database_functions.functions.set_username(cnx, database_type, user_id, username)
+
+            # Update admin role based on OIDC roles.
+            if roles_claim and admin_role:
+                roles = user_info.get(roles_claim)
+                if not isinstance(roles, list):
+                    print(f'Claim {roles_claim} should be a list of strings, but it is {roles}.')
+                    return RedirectResponse(
+                        url=f"{frontend_base}/oauth/callback?error=no_access&details=invalid_roles"
+                    )
+                database_functions.functions.set_isadmin(cnx, database_type, user_id, admin_role in roles)
 
             # Success case - redirect with API key
             return RedirectResponse(url=f"{frontend_base}/oauth/callback?api_key={api_key}")

--- a/database_functions/functions.py
+++ b/database_functions/functions.py
@@ -671,8 +671,10 @@ def add_oidc_provider(cnx, database_type, provider_values):
                 INSERT INTO "OIDCProviders"
                 (ProviderName, ClientID, ClientSecret, AuthorizationURL,
                 TokenURL, UserInfoURL, ButtonText, Scope,
-                ButtonColor, ButtonTextColor, IconSVG)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ButtonColor, ButtonTextColor, IconSVG, NameClaim, EmailClaim,
+                UsernameClaim, RolesClaim, UserRole, AdminRole)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s)
                 RETURNING ProviderID
             """
         else:  # MySQL
@@ -680,8 +682,10 @@ def add_oidc_provider(cnx, database_type, provider_values):
                 INSERT INTO OIDCProviders
                 (ProviderName, ClientID, ClientSecret, AuthorizationURL,
                 TokenURL, UserInfoURL, ButtonText, Scope,
-                ButtonColor, ButtonTextColor, IconSVG)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ButtonColor, ButtonTextColor, IconSVG, NameClaim, EmailClaim,
+                UsernameClaim, RolesClaim, UserRole, AdminRole)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s)
             """
         cursor.execute(add_provider_query, provider_values)
 
@@ -733,16 +737,18 @@ def list_oidc_providers(cnx, database_type):
         if database_type == "postgresql":
             list_query = """
                 SELECT ProviderID, ProviderName, ClientID, AuthorizationURL,
-                TokenURL, UserInfoURL, ButtonText,
-                Scope, ButtonColor, ButtonTextColor, IconSVG, Enabled, Created, Modified
+                TokenURL, UserInfoURL, ButtonText, Scope, ButtonColor,
+                ButtonTextColor, IconSVG, NameClaim, EmailClaim, UsernameClaim,
+                RolesClaim, UserRole, AdminRole, Enabled, Created, Modified
                 FROM "OIDCProviders"
                 ORDER BY ProviderName
             """
         else:
             list_query = """
                 SELECT ProviderID, ProviderName, ClientID, AuthorizationURL,
-                TokenURL, UserInfoURL, ButtonText,
-                Scope, ButtonColor, ButtonTextColor, IconSVG, Enabled, Created, Modified
+                TokenURL, UserInfoURL, ButtonText, Scope, ButtonColor,
+                ButtonTextColor, IconSVG, NameClaim, EmailClaim, UsernameClaim,
+                RolesClaim, UserRole, AdminRole, Enabled, Created, Modified
                 FROM OIDCProviders
                 ORDER BY ProviderName
             """
@@ -776,6 +782,18 @@ def list_oidc_providers(cnx, database_type):
                             normalized["button_text_color"] = value
                         elif normalized_key == "iconsvg":
                             normalized["icon_svg"] = value
+                        elif normalized_key == "nameclaim":
+                            normalized["name_claim"] = value
+                        elif normalized_key == "emailclaim":
+                            normalized["email_claim"] = value
+                        elif normalized_key == "usernameclaim":
+                            normalized["username_claim"] = value
+                        elif normalized_key == "rolesclaim":
+                            normalized["roles_claim"] = value
+                        elif normalized_key == "userrole":
+                            normalized["user_role"] = value
+                        elif normalized_key == "adminrole":
+                            normalized["admin_role"] = value
                         else:
                             normalized[normalized_key] = value
                     providers.append(normalized)
@@ -793,9 +811,15 @@ def list_oidc_providers(cnx, database_type):
                         'button_color': row[8],
                         'button_text_color': row[9],
                         'icon_svg': row[10],
-                        'enabled': row[11],
-                        'created': row[12],
-                        'modified': row[13]
+                        'name_claim': row[11],
+                        'email_claim': row[12],
+                        'username_claim': row[13],
+                        'roles_claim': row[14],
+                        'user_role': row[15],
+                        'admin_role': row[16],
+                        'enabled': row[17],
+                        'created': row[18],
+                        'modified': row[19]
                     })
         else:
             columns = [col[0] for col in cursor.description]
@@ -826,6 +850,18 @@ def list_oidc_providers(cnx, database_type):
                         normalized["button_text_color"] = value
                     elif normalized_key == "iconsvg":
                         normalized["icon_svg"] = value
+                    elif normalized_key == "nameclaim":
+                        normalized["name_claim"] = value
+                    elif normalized_key == "emailclaim":
+                        normalized["email_claim"] = value
+                    elif normalized_key == "usernameclaim":
+                        normalized["username_claim"] = value
+                    elif normalized_key == "rolesclaim":
+                        normalized["roles_claim"] = value
+                    elif normalized_key == "userrole":
+                        normalized["user_role"] = value
+                    elif normalized_key == "adminrole":
+                        normalized["admin_role"] = value
                     elif normalized_key == "enabled":
                         # Convert MySQL TINYINT to boolean
                         normalized["enabled"] = bool(value)
@@ -14657,13 +14693,13 @@ def get_oidc_provider(cnx, database_type, client_id):
     try:
         if database_type == "postgresql":
             query = """
-                SELECT ProviderID, ClientID, ClientSecret, TokenURL, UserInfoURL
+                SELECT ProviderID, ClientID, ClientSecret, TokenURL, UserInfoURL, NameClaim, EmailClaim, UsernameClaim, RolesClaim, UserRole, AdminRole
                 FROM "OIDCProviders"
                 WHERE ClientID = %s AND Enabled = true
             """
         else:
             query = """
-                SELECT ProviderID, ClientID, ClientSecret, TokenURL, UserInfoURL
+                SELECT ProviderID, ClientID, ClientSecret, TokenURL, UserInfoURL, NameClaim, EmailClaim, UsernameClaim, RolesClaim, UserRole, AdminRole
                 FROM OIDCProviders
                 WHERE ClientID = %s AND Enabled = true
             """
@@ -14676,7 +14712,13 @@ def get_oidc_provider(cnx, database_type, client_id):
                     result['clientid'],
                     result['clientsecret'],
                     result['tokenurl'],
-                    result['userinfourl']
+                    result['userinfourl'],
+                    result['nameclaim'],
+                    result['emailclaim'],
+                    result['usernameclaim'],
+                    result['rolesclaim'],
+                    result['userrole'],
+                    result['adminrole']
                 )
             return result
         return None
@@ -14714,49 +14756,10 @@ def get_user_by_email(cnx, database_type, email):
     finally:
         cursor.close()
 
-def create_oidc_user(cnx, database_type, email, fullname, base_username):
+def create_oidc_user(cnx, database_type, email, fullname, username):
     cursor = cnx.cursor()
     try:
-        print(f"Starting create_oidc_user for email: {email}, fullname: {fullname}, base_username: {base_username}")
-        # Check if username exists and find a unique one
-        username = base_username
-        counter = 1
-        while True:
-            # Check if username exists
-            check_query = """
-                SELECT COUNT(*) FROM "Users" WHERE Username = %s
-            """ if database_type == "postgresql" else """
-                SELECT COUNT(*) FROM Users WHERE Username = %s
-            """
-            print(f"Checking if username '{username}' exists")
-            cursor.execute(check_query, (username,))
-            result = cursor.fetchone()
-            print(f"Username check result: {result}, type: {type(result)}")
-
-            count = 0
-            if isinstance(result, tuple):
-                count = result[0]
-            elif isinstance(result, dict):
-                count = result.get('count', 0)
-            else:
-                # Try to extract the count value safely
-                try:
-                    count = int(result)
-                except (TypeError, ValueError):
-                    print(f"Unable to extract count from result: {result}")
-                    count = 1  # Assume username exists to be safe
-
-            print(f"Username count: {count}")
-            if count == 0:
-                print(f"Username '{username}' is unique, proceeding")
-                break  # Username is unique
-
-            # Try with incremented counter
-            print(f"Username '{username}' already exists, trying next")
-            username = f"{base_username}{counter}"
-            counter += 1
-            if counter > 10:  # Limit attempts
-                raise Exception("Could not find a unique username")
+        print(f"Starting create_oidc_user for email: {email}, fullname: {fullname}, username: {username}")
 
         # Create a random salt using base64 (which is what Argon2 expects)
         salt = base64.b64encode(secrets.token_bytes(16)).decode('utf-8')

--- a/database_functions/migration_definitions.py
+++ b/database_functions/migration_definitions.py
@@ -1712,7 +1712,41 @@ def fix_missing_rss_tables(conn, db_type: str) -> None:
             logger.info("RssKeyMap table already exists")
         
         logger.info("Missing RSS tables migration completed")
+
+    finally:
+        cursor.close()
     
+
+# Migration 015: OIDC settings for claims & roles.
+@register_migration("015", "oidc_claims_and_roles", "Add columns for OIDC claims & roles settings", requires=["002"])
+def migration_015_oidc_claims_and_roles(conn, db_type: str):
+    """Add columns for OIDC claims & roles settings"""
+    cursor = conn.cursor()
+
+    try:
+        if db_type == "postgresql":
+            cursor.execute("""
+                ALTER TABLE "OIDCProviders"
+                ADD COLUMN IF NOT EXISTS NameClaim VARCHAR(255),
+                ADD COLUMN IF NOT EXISTS EmailClaim VARCHAR(255),
+                ADD COLUMN IF NOT EXISTS UsernameClaim VARCHAR(255),
+                ADD COLUMN IF NOT EXISTS RolesClaim VARCHAR(255),
+                ADD COLUMN IF NOT EXISTS UserRole VARCHAR(255),
+                ADD COLUMN IF NOT EXISTS AdminRole VARCHAR(255);
+            """)
+        else:
+            cursor.execute("""
+                ALTER TABLE OIDCProviders
+                ADD COLUMN NameClaim VARCHAR(255) AFTER IconSVG,
+                ADD COLUMN EmailClaim VARCHAR(255) AFTER NameClaim,
+                ADD COLUMN UsernameClaim VARCHAR(255) AFTER EmailClaim,
+                ADD COLUMN RolesClaim VARCHAR(255) AFTER UsernameClaim,
+                ADD COLUMN UserRole VARCHAR(255) AFTER RolesClaim,
+                ADD COLUMN AdminRole VARCHAR(255) AFTER UserRole;
+            """)
+
+        logger.info("Added claim & roles settings to OIDC table")
+
     finally:
         cursor.close()
 

--- a/web/src/components/oauth_callback.rs
+++ b/web/src/components/oauth_callback.rs
@@ -327,6 +327,7 @@ pub fn oauth_callback() -> Html {
                         "username_conflict" => "Unable to create account - username already exists",
                         "authentication_failed" => "Authentication failed. Please try again.",
                         "invalid_provider" => "Invalid authentication provider.",
+                        "no_access" => "Access denied.",
                         _ => "An unexpected error occurred during login.",
                     };
                     page_state.set(PageState::Error(error_message.into()));

--- a/web/src/components/setting_components/oidc.rs
+++ b/web/src/components/setting_components/oidc.rs
@@ -385,6 +385,12 @@ pub fn oidc_settings() -> Html {
     let button_color = use_state(|| String::from("#000000"));
     let button_text_color = use_state(|| String::from("#000000"));
     let icon_svg = use_state(|| String::new());
+    let name_claim = use_state(|| String::new());
+    let email_claim = use_state(|| String::new());
+    let username_claim = use_state(|| String::new());
+    let roles_claim = use_state(|| String::new());
+    let user_role = use_state(|| String::new());
+    let admin_role = use_state(|| String::new());
     // Add this to your state declarations in the form component
     let selected_scopes = use_state(|| Vec::<String>::new());
 
@@ -586,6 +592,54 @@ pub fn oidc_settings() -> Html {
         })
     };
 
+    let on_name_claim_change = {
+        let name_claim = name_claim.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_unchecked_into::<HtmlInputElement>();
+            name_claim.set(target.value());
+        })
+    };
+
+    let on_email_claim_change = {
+        let email_claim = email_claim.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_unchecked_into::<HtmlInputElement>();
+            email_claim.set(target.value());
+        })
+    };
+
+    let on_username_claim_change = {
+        let username_claim = username_claim.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_unchecked_into::<HtmlInputElement>();
+            username_claim.set(target.value());
+        })
+    };
+
+    let on_roles_claim_change = {
+        let roles_claim = roles_claim.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_unchecked_into::<HtmlInputElement>();
+            roles_claim.set(target.value());
+        })
+    };
+
+    let on_user_role_change = {
+        let user_role = user_role.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_unchecked_into::<HtmlInputElement>();
+            user_role.set(target.value());
+        })
+    };
+
+    let on_admin_role_change = {
+        let admin_role = admin_role.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_unchecked_into::<HtmlInputElement>();
+            admin_role.set(target.value());
+        })
+    };
+
     let submit_state = state.clone();
     let on_submit = {
         let provider_name = provider_name.clone();
@@ -598,6 +652,12 @@ pub fn oidc_settings() -> Html {
         let button_color = button_color.clone();
         let button_text_color = button_text_color.clone();
         let icon_svg = icon_svg.clone();
+        let name_claim = name_claim.clone();
+        let email_claim = email_claim.clone();
+        let username_claim = username_claim.clone();
+        let roles_claim = roles_claim.clone();
+        let user_role = user_role.clone();
+        let admin_role = admin_role.clone();
         let page_state = page_state.clone();
         let update_trigger = update_trigger.clone();
         let _dispatch = _dispatch.clone();
@@ -627,6 +687,12 @@ pub fn oidc_settings() -> Html {
                 button_color: Some((*button_color).clone()),
                 button_text_color: Some((*button_text_color).clone()),
                 icon_svg: Some((*icon_svg).clone()),
+                name_claim: Some((*name_claim).clone()),
+                email_claim: Some((*email_claim).clone()),
+                username_claim: Some((*username_claim).clone()),
+                roles_claim: Some((*roles_claim).clone()),
+                user_role: Some((*user_role).clone()),
+                admin_role: Some((*admin_role).clone()),
             };
 
             // Rest of your submission code...
@@ -832,6 +898,60 @@ pub fn oidc_settings() -> Html {
                                         value={(*icon_svg).clone()}
                                         oninput={on_icon_svg_change}
                                         placeholder="<svg>...</svg>"
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{"Name Claim"}</label>
+                                    <input
+                                        type="text"
+                                        class="form-input"
+                                        value={(*name_claim).clone()}
+                                        oninput={on_name_claim_change}
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{"Email Claim"}</label>
+                                    <input
+                                        type="text"
+                                        class="form-input"
+                                        value={(*email_claim).clone()}
+                                        oninput={on_email_claim_change}
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{"Username Claim"}</label>
+                                    <input
+                                        type="text"
+                                        class="form-input"
+                                        value={(*username_claim).clone()}
+                                        oninput={on_username_claim_change}
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{"Roles Claim"}</label>
+                                    <input
+                                        type="text"
+                                        class="form-input"
+                                        value={(*roles_claim).clone()}
+                                        oninput={on_roles_claim_change}
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{"User Role"}</label>
+                                    <input
+                                        type="text"
+                                        class="form-input"
+                                        value={(*user_role).clone()}
+                                        oninput={on_user_role_change}
+                                    />
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{"Admin Role"}</label>
+                                    <input
+                                        type="text"
+                                        class="form-input"
+                                        value={(*admin_role).clone()}
+                                        oninput={on_admin_role_change}
                                     />
                                 </div>
                             </div>

--- a/web/src/requests/setting_reqs.rs
+++ b/web/src/requests/setting_reqs.rs
@@ -2104,6 +2104,12 @@ pub struct AddOIDCProviderRequest {
     pub button_color: Option<String>,
     pub button_text_color: Option<String>,
     pub icon_svg: Option<String>,
+    pub name_claim: Option<String>,
+    pub email_claim: Option<String>,
+    pub username_claim: Option<String>,
+    pub roles_claim: Option<String>,
+    pub user_role: Option<String>,
+    pub admin_role: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2120,6 +2126,12 @@ pub struct OIDCProvider {
     pub button_color: String,
     pub button_text_color: String,
     pub icon_svg: Option<String>,
+    pub name_claim: Option<String>,
+    pub email_claim: Option<String>,
+    pub username_claim: Option<String>,
+    pub roles_claim: Option<String>,
+    pub user_role: Option<String>,
+    pub admin_role: Option<String>,
     pub enabled: bool,
 }
 


### PR DESCRIPTION
This introduces new settings to tune the OIDC user creation & the
permissions of the users.

---

The first three are to tune the claims (fields in the OIDC user info)
that are used to for the information of the Pinepods user.

`name_claim` can be used to change the claim used for the user's full
name. If not provided this defaults to `name` which was the claim that
was previously used for this. This will now be updated on login,
allowing existing users to be updated if their name changes in the OIDC
provider or if the claim used for this is changed.

`email_claim` can be used to change the claim used for the user's email
address. If not provided this defaults to `email` which was the claim
that was previously always used for this. Note that this is the field
that is used to find an existing account when logging in, so changes to
this claim may cause users to get a new user account in Pinepods.

`username_claim` can be used to change the claim used for the user's
username. If not provided it will use the `preferred_username` claim if
present and fall back to the old behaviour otherwise (using the portion
of the email before the `@` symbol, possibly with a suffix if already in
use). If provided the user's username will be updated on login if
possible, just like is the case for the full name.

---

The next three are to determine the level of access the user should
have. Previously every OIDC user was a regular user in Pinepods, this
allows changing that.

`roles_claim` can be used to change the claim used for the user's roles.
If not provided this defaults to `roles`.

`user_role` is the name of the role that must be present in the list of
roles in order for the user to be allowed to use the application. If the
user doesn't have either this role or the admin role (if set) they will
not be permitted to use Pinepods at all. If this is not set this check
is skipped and all OIDC users will be able to use Pinepods, as was the
case in the past.

`admin_role` is the name of the role that must be present in the list of
roles in order for the user to be granted admin privileges. If the user
has this role during login they will be granted admin rights, and if
they do not their admin rights will be revoked. If this is not set all
users created by logging into OIDC will start out as regular users (as
was the case in the past) and will only have admin access if this is
explictly given to them by another admin in the settings.
