### PR TITLE
Removed rogue backticks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,6 @@ externalDatabase:
   user: postgres
   password: "your-password"
   database: pinepods_database
-```
     size: 3Gi
 
 valkey:


### PR DESCRIPTION
A rogue triple backtick in the External Database Configuration code block broke the formatting for the rest of the document. Removed it to fix the issues.