### PR TITLE
Update docker-compose.yml

### DIFF
--- a/deployment/docker/compose-files/docker-compose-postgres/docker-compose.yml
+++ b/deployment/docker/compose-files/docker-compose-postgres/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: myS3curepass
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
-      - /home/user/pinepods/pgdata:/var/lib/postgresql/data
+      - /home/user/pinepods/pgdata:/var/lib/postgresql
     ports:
       - "5432:5432"
     restart: always


### PR DESCRIPTION
Changed volumes mount as per https://github.com/docker-library/postgres/issues/1363

WARNING: This breaks current installs

Not sure how you want to handle this so current users don't break their installs, but figured this would be a good place to let you know about the issue and suggest a change for new users at least. It seems if you pull/update the DB (since yesterday) you'll run into an error starting the DB.