### PR TITLE
Fix horust memory leak

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -106,7 +106,7 @@ RUN LATEST_VERSION=$(curl -s https://api.github.com/repos/yt-dlp/yt-dlp/releases
     chmod +x /usr/local/bin/yt-dlp
 
 # Download and install Horust (x86_64)
-RUN wget -O /tmp/horust.tar.gz "https://github.com/FedericoPonzi/Horust/releases/download/v0.1.7/horust-x86_64-unknown-linux-musl.tar.gz" && \
+RUN wget -O /tmp/horust.tar.gz "https://github.com/FedericoPonzi/Horust/releases/download/v0.1.11/horust-x86_64-unknown-linux-musl.tar.gz" && \
     cd /tmp && tar -xzf horust.tar.gz && \
     mv horust /usr/local/bin/ && \
     chmod +x /usr/local/bin/horust && \


### PR DESCRIPTION
After running PinePods for about a month, `horust` accumulated ~1.2 GB of memory:
```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root        4202  0.0  3.8 1740960 1261496 ?     Ssl  Oct22  33:15  \_ horust --services-path /etc/horust/services/
root        6747  0.0  0.0  45752 13988 ?        Ssl  Oct22  28:43      \_ /usr/local/bin/pinepods-api
root        6910  0.0  0.0 1236524 2136 ?        Ssl  Oct22   0:02      \_ /usr/local/bin/gpodder-api
root        7103  0.0  0.0  10172     8 ?        Ss   Oct22   0:00      \_ nginx: master process nginx -g daemon off;
message+    7109  0.0  0.0  10440   364 ?        S    Oct22   0:01          \_ nginx: worker process
```

Based on https://github.com/FedericoPonzi/Horust/issues/201, there was a memory issue in older versions, including version `0.1.7`, which should be solved now.