### PR TITLE
Add Accept and User-Agent headers when downloading episodes

### DIFF
--- a/rust-api/src/services/tasks.rs
+++ b/rust-api/src/services/tasks.rs
@@ -99,6 +99,8 @@ async fn download_episode_and_wait(
     // Download the file
     let client = reqwest::Client::new();
     let mut response = client.get(&episode_url)
+        .header("Accept", "*/*")
+        .header("User-Agent", "PinePods/1.0")
         .send()
         .await
         .map_err(|e| crate::error::AppError::Internal(format!("Failed to start download: {}", e)))?;


### PR DESCRIPTION
Fixes Darknet Diaries Plus subscriber feed (https://github.com/madeofpendletonwool/PinePods/issues/333#issuecomment-3751119124), and possibly other podcasts hosted behind Amazon Cloudfront, which doesn't seem to like the default/missing `reqwest` GET request headers.