### PR TITLE
fix: skip current episode when selecting next from queue

### DIFF
--- a/web/src/components/audio.rs
+++ b/web/src/components/audio.rs
@@ -976,8 +976,17 @@ pub fn audio_player(props: &AudioPlayerProps) -> Html {
                                         }
 
                                         // Now play the first episode in the queue (which is the next one to play)
-                                        // Sort by queue position to ensure we get the right one
-                                        let mut sorted_episodes = episodes.clone();
+                                        // Sort by queue position to ensure we get the right one.
+                                        // Filter out the current episode — episodes was fetched before
+                                        // the removal API call, so it still contains the just-finished
+                                        // episode. Without this filter, sorted_episodes.first() returns
+                                        // the current episode (lowest queue position), causing it to
+                                        // replay from the beginning instead of advancing to the next one.
+                                        let current_id = current_episode_id.unwrap();
+                                        let mut sorted_episodes: Vec<_> = episodes
+                                            .into_iter()
+                                            .filter(|ep| ep.episodeid != current_id)
+                                            .collect();
                                         sorted_episodes
                                             .sort_by_key(|ep| ep.queueposition.unwrap_or(999999));
 


### PR DESCRIPTION
## Problem

When an episode ends, the `ended` event handler:

1. Fetches the current queue (API call returns a list that **still includes the just-finished episode**)
2. Calls the API to remove the finished episode from the queue (async — not yet complete)
3. Sorts the fetched list by `queueposition` and calls `.first()` to find the next episode

Since the finished episode has the **lowest queue position** (it was at the front), `sorted_episodes.first()` returns it — causing the player to replay the current episode from the beginning instead of advancing to the next one.

This manifests as:
- Player appearing to rewind and replay the last few seconds of the current episode
- Occasional infinite replay of the same episode
- Next episode only advancing intermittently (race condition with the removal API call)

## Fix

Filter the current episode out of the candidate list before sorting:

```rust
let current_id = current_episode_id.unwrap();
let mut sorted_episodes: Vec<_> = episodes
    .into_iter()
    .filter(|ep| ep.episodeid != current_id)
    .collect();
sorted_episodes.sort_by_key(|ep| ep.queueposition.unwrap_or(999999));
```

This ensures `sorted_episodes.first()` always returns the true next episode in the queue, regardless of when the removal API call completes.

## Testing

Tested with a queue of 3+ episodes at 1.5× playback speed. Episodes now transition cleanly without replaying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)