### PR TITLE
Fix SSRF via attacker-controlled podcast enclosure URL (GHSA-j876-2282-p4hg)

### DIFF
--- a/rust-api/src/database.rs
+++ b/rust-api/src/database.rs
@@ -6900,11 +6900,26 @@ impl DatabasePool {
     // This is a fallback for when RSS feeds don't include duration or file size
     async fn estimate_duration_from_audio_url_async(&self, audio_url: &str) -> Option<i32> {
         println!("Attempting to estimate duration from audio URL: {}", audio_url);
-        
-        // Build HTTP client with timeout to avoid hanging
+
+        // SSRF guard: audio_url is the attacker-controlled RSS <enclosure url>.
+        // Reject loopback/private/link-local/reserved destinations before any
+        // server-side request (incl. redirect hops).
+        if let Err(reason) = crate::services::url_guard::ensure_safe_public_url_async(audio_url).await {
+            println!("Refusing to estimate duration for unsafe URL: {}", reason);
+            return None;
+        }
+
+        // Build HTTP client with timeout to avoid hanging. Redirects are
+        // re-validated so a public URL cannot 30x into the internal network.
         let client = match reqwest::Client::builder()
             .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
             .timeout(std::time::Duration::from_secs(10)) // Short timeout
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                match crate::services::url_guard::ensure_safe_public_url(attempt.url().as_str()) {
+                    Ok(()) => attempt.follow(),
+                    Err(_) => attempt.stop(),
+                }
+            }))
             .build()
         {
             Ok(client) => client,

--- a/rust-api/src/services/mod.rs
+++ b/rust-api/src/services/mod.rs
@@ -3,5 +3,6 @@ pub mod podcast;
 pub mod scheduler;
 pub mod task_manager;
 pub mod tasks;
+pub mod url_guard;
 
 // Common service utilities and shared functionality

--- a/rust-api/src/services/tasks.rs
+++ b/rust-api/src/services/tasks.rs
@@ -96,8 +96,24 @@ async fn download_episode_and_wait(
     let filename = format!("{}_{}_{}_{}.mp3", pub_date_str, safe_episode_title, user_id, episode_id);
     let file_path = download_dir.join(&filename);
     
-    // Download the file
-    let client = reqwest::Client::new();
+    // SSRF guard: episode_url originates from the podcast RSS <enclosure url>,
+    // which is fully attacker-controlled. Reject loopback/private/link-local/
+    // reserved destinations before issuing any server-side request.
+    crate::services::url_guard::ensure_safe_public_url_async(&episode_url)
+        .await
+        .map_err(|reason| crate::error::AppError::Internal(format!("Refusing to download episode URL: {}", reason)))?;
+
+    // Download the file. Redirects are re-validated by the same guard so a
+    // public URL cannot 30x-redirect into the internal network.
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            match crate::services::url_guard::ensure_safe_public_url(attempt.url().as_str()) {
+                Ok(()) => attempt.follow(),
+                Err(_) => attempt.stop(),
+            }
+        }))
+        .build()
+        .map_err(|e| crate::error::AppError::Internal(format!("Failed to build HTTP client: {}", e)))?;
     let mut response = client.get(&episode_url)
         .header("Accept", "*/*")
         .header("User-Agent", "PinePods/1.0")

--- a/rust-api/src/services/url_guard.rs
+++ b/rust-api/src/services/url_guard.rs
@@ -39,7 +39,6 @@ fn is_blocked_v4(v4: Ipv4Addr) -> bool {
         || v4.is_unspecified()  // 0.0.0.0
         || v4.is_broadcast()    // 255.255.255.255
         || v4.is_documentation()
-        || v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 64 // 100.64.0.0/10 CGNAT
         || v4.octets()[0] >= 240 // 240.0.0.0/4 reserved
 }
 

--- a/rust-api/src/services/url_guard.rs
+++ b/rust-api/src/services/url_guard.rs
@@ -1,0 +1,144 @@
+// SSRF guard for server-side fetches of attacker-controlled URLs (e.g. podcast
+// RSS enclosure URLs). Restricts the scheme to http/https and rejects any URL
+// whose host resolves to a loopback, link-local, private, unique-local,
+// unspecified or otherwise reserved address. IPv4-mapped IPv6 (::ffff:a.b.c.d)
+// and NAT64 (64:ff9b::/96) forms are unwrapped before classification so they
+// cannot be used to smuggle an internal IPv4 address past the check.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
+
+/// Returns true if `ip` must never be the target of a server-side fetch.
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_v4(v4),
+        IpAddr::V6(v6) => {
+            // Unwrap IPv4-mapped (::ffff:a.b.c.d) form and re-check as IPv4 so an
+            // internal v4 target cannot be smuggled. Use to_ipv4_mapped() rather
+            // than to_ipv4() — the latter also maps IPv4-compatible addresses
+            // such as ::1 to 0.0.0.1, which would bypass the loopback check.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_blocked_v4(v4);
+            }
+            // NAT64 well-known prefix 64:ff9b::/96 embeds an IPv4 address in the
+            // low 32 bits; unwrap and re-check.
+            let seg = v6.segments();
+            if seg[0] == 0x0064 && seg[1] == 0xff9b && seg[2] == 0 && seg[3] == 0 && seg[4] == 0 && seg[5] == 0 {
+                let o = v6.octets();
+                let v4 = Ipv4Addr::new(o[12], o[13], o[14], o[15]);
+                return is_blocked_v4(v4);
+            }
+            is_blocked_v6(v6)
+        }
+    }
+}
+
+fn is_blocked_v4(v4: Ipv4Addr) -> bool {
+    v4.is_loopback()            // 127.0.0.0/8
+        || v4.is_private()      // 10/8, 172.16/12, 192.168/16
+        || v4.is_link_local()   // 169.254.0.0/16 (incl. cloud metadata)
+        || v4.is_unspecified()  // 0.0.0.0
+        || v4.is_broadcast()    // 255.255.255.255
+        || v4.is_documentation()
+        || v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 64 // 100.64.0.0/10 CGNAT
+        || v4.octets()[0] >= 240 // 240.0.0.0/4 reserved
+}
+
+fn is_blocked_v6(v6: Ipv6Addr) -> bool {
+    v6.is_loopback()            // ::1
+        || v6.is_unspecified()  // ::
+        || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        || (v6.segments()[0] & 0xfe00) == 0xfc00 // fc00::/7 unique-local
+        || (v6.segments()[0] & 0xff00) == 0xff00 // ff00::/8 multicast
+}
+
+/// Validate a URL before any server-side fetch.
+///
+/// Returns Ok(()) only if the scheme is http/https and *every* address the host
+/// resolves to is a public, routable address. Resolution failure or any blocked
+/// address yields Err with a short reason.
+pub fn ensure_safe_public_url(raw_url: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(raw_url).map_err(|e| format!("invalid URL: {}", e))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => return Err(format!("scheme '{}' not allowed (only http/https)", other)),
+    }
+
+    let host_raw = parsed
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?
+        .to_string();
+
+    // url::Url::host_str() returns IPv6 literals wrapped in brackets
+    // (e.g. "[::1]"); strip them before attempting a literal-IP parse.
+    let host = host_raw
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .map(|h| h.to_string())
+        .unwrap_or(host_raw);
+
+    // If the host is already a literal IP, classify it directly.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return if is_blocked_ip(ip) {
+            Err(format!("destination IP {} is private/reserved", ip))
+        } else {
+            Ok(())
+        };
+    }
+
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let addrs: Vec<IpAddr> = (host.as_str(), port)
+        .to_socket_addrs()
+        .map_err(|e| format!("could not resolve host '{}': {}", host, e))?
+        .map(|sa| sa.ip())
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(format!("host '{}' resolved to no addresses", host));
+    }
+    for ip in &addrs {
+        if is_blocked_ip(*ip) {
+            return Err(format!(
+                "host '{}' resolves to private/reserved address {}",
+                host, ip
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Async wrapper: DNS resolution is blocking, so run the check off the async
+/// executor.
+pub async fn ensure_safe_public_url_async(raw_url: &str) -> Result<(), String> {
+    let owned = raw_url.to_string();
+    tokio::task::spawn_blocking(move || ensure_safe_public_url(&owned))
+        .await
+        .map_err(|e| format!("URL guard task failed: {}", e))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_loopback_and_metadata_and_private() {
+        for u in [
+            "http://127.0.0.1:8040/api/pinepods_check",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::ffff:169.254.169.254]/",
+            "http://[64:ff9b::a9fe:a9fe]/",
+            "http://10.0.0.5/",
+            "http://192.168.1.1/",
+            "http://[::1]/",
+            "gopher://127.0.0.1/",
+            "file:///etc/passwd",
+        ] {
+            assert!(ensure_safe_public_url(u).is_err(), "should block {}", u);
+        }
+    }
+
+    #[test]
+    fn allows_public_literal() {
+        assert!(ensure_safe_public_url("http://93.184.216.34/audio.mp3").is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `services::url_guard::ensure_safe_public_url()` — http/https scheme allowlist plus resolve-and-reject of loopback / private / link-local / unique-local / reserved addresses, unwrapping IPv4-mapped (`::ffff:`) and NAT64 (`64:ff9b::/96`) IPv6 forms so an internal IPv4 target cannot be smuggled.
- Wires the guard in before the `reqwest` GET in `download_episode_and_wait` (`services/tasks.rs`) and before the HEAD in `estimate_duration_from_audio_url_async` (`database.rs`).
- Installs a redirect policy that re-validates every hop so a public URL cannot 30x-redirect into the internal network.
- Local tweak vs the reporter's patch: dropped the 100.64.0.0/10 (CGNAT) block so podcast feeds served from Tailscale peers still work — a real homelab use case.

## Context
Reported by @tonghuaroot as GHSA-j876-2282-p4hg. The podcast RSS `<enclosure url>` is fully attacker-controlled and was previously fetched server-side with no host validation, with the response body saved to disk as the "episode" — turning blind SSRF into a read-back primitive (cloud metadata, loopback to the PinePods API itself, RFC1918 hosts on the same docker network, etc.). Fetch requires an authenticated session.

Original commit authored by @tonghuaroot, cherry-picked from the advisory's temporary private fork. Follow-up commit removes the CGNAT block.

## Test plan
- [x] `cargo check` clean
- [x] `cargo test services::url_guard::` — both tests pass (`blocks_loopback_and_metadata_and_private`, `allows_public_literal`)
- [ ] Manual: subscribe to a feed with an enclosure pointing at `http://127.0.0.1:8040/api/pinepods_check`, trigger download → expect "Refusing to download episode URL" in logs, no file saved
- [ ] Manual: subscribe to a normal public podcast → episode downloads as before
- [ ] Manual: subscribe to a feed served from a Tailscale peer (100.64.x.x) → should still work

## Follow-ups (not in this PR)
- TOCTOU / DNS rebinding: guard resolves at check time, `reqwest` re-resolves at connect time. Defense in depth would be connecting to the validated IP directly via `Client::resolve()`. Closing the obvious holes first.