### PR TITLE
Web: skip current episode when selecting next from queue

### DIFF
--- a/web/src/components/audio.rs
+++ b/web/src/components/audio.rs
@@ -976,8 +976,17 @@ pub fn audio_player(props: &AudioPlayerProps) -> Html {
                                         }
 
                                         // Now play the first episode in the queue (which is the next one to play)
-                                        // Sort by queue position to ensure we get the right one
-                                        let mut sorted_episodes = episodes.clone();
+                                        // Sort by queue position to ensure we get the right one.
+                                        // Filter out the current episode — episodes was fetched before
+                                        // the removal API call, so it still contains the just-finished
+                                        // episode. Without this filter, sorted_episodes.first() returns
+                                        // the current episode (lowest queue position), causing it to
+                                        // replay from the beginning instead of advancing to the next one.
+                                        let current_id = current_episode_id.unwrap();
+                                        let mut sorted_episodes: Vec<_> = episodes
+                                            .into_iter()
+                                            .filter(|ep| ep.episodeid != current_id)
+                                            .collect();
                                         sorted_episodes
                                             .sort_by_key(|ep| ep.queueposition.unwrap_or(999999));
 


### PR DESCRIPTION
Closes #893

## Summary
- On the web player, the queue was fetched before the removal API call for the just-finished episode completed, so `sorted_episodes` still contained that episode - and since it had the lowest queue position, it was picked as "next," causing a replay from the beginning instead of advancing.
- `web/src/components/audio.rs` now filters the current episode out of the candidate list before sorting, so `sorted_episodes.first()` always returns the true next episode.

## Test plan
- [x] `web` crate builds cleanly on `wasm32-unknown-unknown`
- [x] `cargo test` - existing regression test suite passes (5/5)
