### PR TITLE
Web: add 20 i18n keys missing from en.json (#889)

### DIFF
--- a/web/src/translations/en.json
+++ b/web/src/translations/en.json
@@ -356,6 +356,7 @@
     "unsave": "Unsave",
     "view_transcript": "View Transcript"
   },
+  "failed_to_find_podcast_metadata": "Failed to find podcast's metadata.",
   "episode_list_item": {
     "completed": "Completed"
   },
@@ -781,7 +782,14 @@
     "nextcloud_advanced_hint": "If you need more advanced sync features (like device management), consider using the internal gpodder API or a dedicated gpodder server instead.",
     "external_gpodder_active": "External GPodder sync is currently active with ",
     "gpodder_full_sync": "GPodder sync provides full podcast synchronization capabilities including managing multiple devices, subscription synchronization, and episode status tracking.",
-    "gpodder_compatible": "You can use this sync method with any gpodder-compatible clients like AntennaPod, and others."
+    "gpodder_compatible": "You can use this sync method with any gpodder-compatible clients like AntennaPod, and others.",
+    "no_statistics_available": "No Statistics Available",
+    "click_refresh": "Click refresh above to load statistics.",
+    "loading_default_device": "Loading default device...",
+    "no_default_device_set": "No Default Device Set",
+    "gpodder_device_mgmt": "Device management for this sync method is handled directly on your GPodder server.",
+    "no_sync_configured": "No sync method configured yet.",
+    "testing": "Testing..."
   },
   "notification_center": {
     "active_tasks": "Active Tasks",
@@ -881,7 +889,9 @@
     "time_zone": "Time Zone",
     "time_zone_setup": "Time Zone Setup",
     "unexpected_error": "An unexpected error occurred during login.",
-    "username_conflict": "Unable to create account - username already exists"
+    "username_conflict": "Unable to create account - username already exists",
+    "date_format_iso8601": "ISO 8601",
+    "date_format_julian": "YY/DDD (Julian)"
   },
   "oidc": {
     "add_oidc_provider": "Add OIDC Provider",
@@ -913,7 +923,14 @@
     "use_this_url_when_configuring": "Use this URL when configuring your OIDC provider's callback/redirect settings.",
     "user_info_url": "User Info URL",
     "user_role": "User Role",
-    "username_claim": "Username Claim"
+    "username_claim": "Username Claim",
+    "environment": "Environment",
+    "failed_to_update_provider": "Failed to update provider: ",
+    "github_provider_detected": "GitHub Provider Detected",
+    "github_no_standard_scopes": "GitHub does not support standard OIDC scopes.",
+    "standard_oidc_scopes": "Standard OIDC Scopes",
+    "github_scopes": "GitHub Scopes",
+    "google_scopes": "Google Scopes"
   },
   "people_subs": {
     "avatar_alt": "Avatar for",
@@ -1076,7 +1093,10 @@
     "match_btn": "Match",
     "enter_podcast_id": "Search By Podcast Index ID",
     "search": "Search",
-    "searching": "Searching..."
+    "searching": "Searching...",
+    "loading_podcasts": "Loading Podcasts...",
+    "no_matches_found": "No Matches Found",
+    "try_manual_search": "Try a manual search below."
   },
   "podcast_layout": {
     "add_error": "Error adding podcast",


### PR DESCRIPTION
Closes #889.

`check_i18n_coverage.py` flags 20 `i18n.t(...)` calls in the Rust web frontend with no matching entry in `en.json`. This adds all 20, with wording read from each call site's surrounding UI context and matched to the tone and casing of neighboring keys in the same section.

One key (`failed_to_find_podcast_metadata`) is called without its usual `episode.` namespace prefix in `episode.rs`, likely a naming slip in the original commit. Renaming the call site would need verification against every consumer, so this PR adds the matching top-level key as-is rather than touching the Rust source.

The two `oauth_callback` date-format keys reuse the exact strings from `login.date_format_iso8601` / `.date_format_julian`, since `oauth_callback.rs`'s date-format dropdown duplicates the one on the login page.

Only `en.json` is touched; other locale files are left for translators, per the check script's own stated fix and how this repo already handles per-locale lag.

Verification: `python .github/scripts/check_i18n_coverage.py web/src web/src/translations/en.json` now exits 0 (was exit 1, reporting these same 20 keys). JSON validated with `json.load`. Not verified: web crate build (no Rust toolchain in my environment).
