### PR TITLE
Web: fix podcast_index_id lost when subscribing from episode preview (#886)

### DIFF
--- a/web/src/pages/episode_layout.rs
+++ b/web/src/pages/episode_layout.rs
@@ -3406,7 +3406,14 @@ pub fn episode_layout() -> Html {
                 let i18n_podcast_successfully_added = i18n_podcast_successfully_added.clone();
                 let i18n_failed_to_add_podcast = i18n_failed_to_add_podcast.clone();
                 let callback_podcast_id = added_id.clone();
-                let podcast_id_og = pod_values.clone().unwrap().podcastid.clone();
+                // Use podcastindexid, not podcastid: get_podcast_details_dynamic always
+                // returns podcastid=0 for a podcast that hasn't been added yet (there's no
+                // row in the Podcasts table for it), while podcastindexid carries the real
+                // Podcast Index feed ID threaded through from the search result. Passing
+                // podcastid here persists podcast_index_id=0 on add, so the podcast shows
+                // up as unmatched on the Podcast Index Matching settings page even though
+                // it was subscribed straight from a Podcast Index search result (#886).
+                let podcast_id_og = pod_values.clone().unwrap().podcastindexid.clone();
                 let pod_title_og = pod_values.clone().unwrap().podcastname.clone();
                 let pod_artwork_og = pod_values.clone().unwrap().artworkurl.clone();
                 let pod_author_og = pod_values.clone().unwrap().author.clone();


### PR DESCRIPTION
Fixes #886.

The reported symptom ("podcasts I subscribe to via Podcast Index search still need manual matching, only when self-hosting the backend") isn't actually caused by self-hosting. The self-hosted search proxy's auth and results are correct (verified against the reporter's own logs and the Podcast Index API's documented auth-hash scheme). It's a frontend bug that happens to line up with the reporter's usage pattern:

Clicking a search result's tile (rather than its dedicated "+" button) opens the episode preview page (`episode_layout.rs`) before subscribing. Its subscribe button read `pod_values.podcastid`, which `get_podcast_details_dynamic` always returns as `0` for a not-yet-added podcast (there's no DB row yet), instead of `pod_values.podcastindexid`, which correctly carries the real Podcast Index feed ID. That persisted `podcastindexid = 0` on every podcast added this way, which is exactly the condition `get_unmatched_podcasts` uses to flag a podcast as needing a manual match.

The existing manual-match UI (`podcast_index_matching.rs`) already uses the correct `result.index_id` field, confirming this was the intended field throughout the codebase.

One-line fix: read `podcastindexid` instead of `podcastid` in `episode_layout.rs`'s `toggle_podcast` callback.

Verification: full static trace of the add-podcast data path from search result to DB insert to the unmatched-podcasts query, cross-checked against the codebase's own correct usage elsewhere. Not verified: no Rust toolchain available to compile the `web` crate, and no live instance to reproduce end-to-end. Happy to have a maintainer or another contributor confirm against a running self-hosted setup.
