### PR TITLE
Fix 500 error viewing MySQL/MariaDB playlists - PodcastIDs decodes as BLOB (#773)

### DIFF
--- a/rust-api/src/database.rs
+++ b/rust-api/src/database.rs
@@ -28883,7 +28883,18 @@ impl DatabasePool {
                 }
                 
                 // 3. PODCAST FILTER - handle JSON array of podcast IDs (MySQL)
-                if let Some(podcast_ids_json) = playlist.try_get::<Option<String>, _>("PodcastIDs")?.as_ref() {
+                // MariaDB's JSON column type is reported over the wire with a binary
+                // charset, so sqlx sees it as SQL type BLOB rather than VARCHAR/TEXT.
+                // Decoding it directly as Option<String> then fails with a "mismatched
+                // types" error on every request (see #773). Decode as raw bytes first,
+                // matching the fallback already used in PlaylistConfig::from_mysql_row,
+                // and only fall back to a direct String decode for installs where the
+                // driver does report a text charset for this column.
+                let podcast_ids_json_owned: Option<String> = match playlist.try_get::<Option<Vec<u8>>, _>("PodcastIDs") {
+                    Ok(bytes_opt) => bytes_opt.map(|bytes| String::from_utf8_lossy(&bytes).into_owned()),
+                    Err(_) => playlist.try_get::<Option<String>, _>("PodcastIDs")?,
+                };
+                if let Some(podcast_ids_json) = podcast_ids_json_owned.as_ref() {
                     if !podcast_ids_json.is_empty() && podcast_ids_json != "[]" && podcast_ids_json != "null" {
                         match serde_json::from_str::<Vec<i32>>(podcast_ids_json) {
                             Ok(podcast_ids) if !podcast_ids.is_empty() && !podcast_ids.contains(&-1) => {
@@ -29052,7 +29063,13 @@ impl DatabasePool {
                 let min_dur_secs: Option<i32> = playlist.try_get("MinDuration")?;
                 let max_dur_secs: Option<i32> = playlist.try_get("MaxDuration")?;
                 let is_system_raw: i8 = playlist.try_get("IsSystemPlaylist")?;
-                let podcast_ids_raw: Option<String> = playlist.try_get("PodcastIDs").ok().flatten();
+                // Same BLOB-vs-VARCHAR decode as the podcast filter above (#773) - without
+                // this, `.ok()` silently swallows the decode error and podcast_ids always
+                // reports as None here on installs where MariaDB reports this column as BLOB.
+                let podcast_ids_raw: Option<String> = match playlist.try_get::<Option<Vec<u8>>, _>("PodcastIDs") {
+                    Ok(bytes_opt) => bytes_opt.map(|bytes| String::from_utf8_lossy(&bytes).into_owned()),
+                    Err(_) => playlist.try_get("PodcastIDs").ok().flatten(),
+                };
                 let podcast_ids: Option<Vec<i32>> = podcast_ids_raw
                     .as_deref()
                     .and_then(|s| serde_json::from_str(s).ok());


### PR DESCRIPTION
Fixes #773.

On MySQL/MariaDB installs, viewing any playlist can 500 with: `error occurred while decoding column "PodcastIDs": mismatched types; ... SQL type \`BLOB\`` (see the log excerpt in the issue thread). `Playlists.PodcastIDs` is a `JSON` column, and MariaDB reports `JSON` columns with a binary charset over the wire, so `sqlx` sees `BLOB` rather than `VARCHAR`/`TEXT`. Decoding it directly as `Option<String>` then fails.

The codebase already found and fixed this exact issue once, in `PlaylistConfig::from_mysql_row` (decode as `Option<Vec<u8>>` first, fall back to `String`) â€” but `get_playlist_episodes_dynamic`'s MySQL branch, which is what actually serves `/api/data/get_playlist_episodes`, has two more direct `Option<String>` reads of the same column that were never updated to match. One of them uses `?`, so it 500s on every playlist view on affected installs; the other uses `.ok()`, so it doesn't crash but silently drops the podcast filter from the response. Postgres is unaffected (`PodcastIDs` is a native `INTEGER[]` there), which matches a reporter's comment that recreating the instance on Postgres "fixed" it for them.

This applies the same already-proven decode pattern to both remaining call sites. No behavior change for installs where this already worked.

Note: `get_playlists` (the `/get_playlists` handler) has one more read of the same `PodcastIDs` JSON column that uses `.ok()`, so it doesn't 500 but silently drops the podcast filter on affected installs. Same root cause; I left it out to keep this PR scoped to the reported crash, but happy to fold it in if you'd prefer one PR.

**Verification:** traced the exact error string in the issue's attached logs to this one line in source; cross-checked the fix against the identical, already-working pattern elsewhere in the same file; confirmed via the migration definitions that `PodcastIDs` is `JSON` for MySQL and a native array for Postgres. Not verified: no Rust toolchain available to me to compile the crate, and no live MariaDB/MySQL instance to reproduce end-to-end â€” I'd appreciate a maintainer or the original reporter confirming against a real MySQL/MariaDB install before merging.
