### PR TITLE
Fix startup.sh clobbering SERVER_URL, breaking RSS feed URLs on some container runtimes (#903)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,18 +184,6 @@ sudo docker compose up -d
 Open `http://localhost:8040` and you'll be prompted to create your first admin
 account. That's it — you're up.
 
-> :information_source: **RSS feed links coming out wrong (e.g. showing your container
-> name instead of your domain)?** PinePods reads `HOSTNAME` above as a convenience and
-> copies it into an internal `SERVER_URL` value used to build absolute URLs for
-> generated RSS feeds (`<link>`, `<guid>`, `<enclosure>`). Some container
-> runtimes/orchestration setups — rootless Podman under a systemd unit is a known
-> case — set their own `HOSTNAME` (the container/pod name) in the environment, which
-> can override the value you passed in. If your RSS feed's episode links look like
-> `pinepods-pod/api/data/stream/...` instead of your real domain, set `SERVER_URL`
-> directly (same value you'd put in `HOSTNAME`) instead of, or in addition to,
-> `HOSTNAME` — PinePods checks for `SERVER_URL` first and, unlike `HOSTNAME`, nothing
-> in the container platform can silently overwrite it.
-
 > :information_source: **On PostgreSQL 18 / upgrading from 17.** New installs default to
 > `postgres:18` and need no special steps. Two things to know when moving an existing
 > install to 18:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ sudo docker compose up -d
 Open `http://localhost:8040` and you'll be prompted to create your first admin
 account. That's it — you're up.
 
+> :information_source: **RSS feed links coming out wrong (e.g. showing your container
+> name instead of your domain)?** PinePods reads `HOSTNAME` above as a convenience and
+> copies it into an internal `SERVER_URL` value used to build absolute URLs for
+> generated RSS feeds (`<link>`, `<guid>`, `<enclosure>`). Some container
+> runtimes/orchestration setups — rootless Podman under a systemd unit is a known
+> case — set their own `HOSTNAME` (the container/pod name) in the environment, which
+> can override the value you passed in. If your RSS feed's episode links look like
+> `pinepods-pod/api/data/stream/...` instead of your real domain, set `SERVER_URL`
+> directly (same value you'd put in `HOSTNAME`) instead of, or in addition to,
+> `HOSTNAME` — PinePods checks for `SERVER_URL` first and, unlike `HOSTNAME`, nothing
+> in the container platform can silently overwrite it.
+
 > :information_source: **On PostgreSQL 18 / upgrading from 17.** New installs default to
 > `postgres:18` and need no special steps. Two things to know when moving an existing
 > install to 18:

--- a/startup/startup.sh
+++ b/startup/startup.sh
@@ -32,9 +32,17 @@ export VALKEY_HOST=${VALKEY_HOST:-'valkey'}
 export VALKEY_PORT=${VALKEY_PORT:-'6379'}
 export DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-'en'}
 
-# Save user's HOSTNAME to SERVER_URL before Docker overwrites it with container ID
-# This preserves the user-configured server URL for RSS feed generation
-export SERVER_URL=${HOSTNAME}
+# Fall back to HOSTNAME for SERVER_URL if SERVER_URL isn't already set.
+# IMPORTANT: this must NOT unconditionally overwrite SERVER_URL. Some container
+# runtimes/orchestration setups (e.g. rootless Podman under a systemd unit) set
+# their own HOSTNAME (the container/pod name) in the environment, which can
+# arrive *after* a user's `-e HOSTNAME=...` and win, or otherwise take
+# precedence over it. When that happens this line used to clobber SERVER_URL
+# with that runtime-assigned value every time, breaking RSS feed generation
+# (absolute URLs for <link>/<guid>/<enclosure> end up using the container name
+# instead of the configured domain - see #903). Setting SERVER_URL directly
+# is not affected by that problem, so respect it if the user already set it.
+export SERVER_URL=${SERVER_URL:-$HOSTNAME}
 
 # Export OIDC environment variables
 export OIDC_DISABLE_STANDARD_LOGIN=${OIDC_DISABLE_STANDARD_LOGIN:-'false'}


### PR DESCRIPTION
Fixes #903.

`startup.sh` sets `SERVER_URL` (used to build absolute `<link>`/`<guid>`/ `<enclosure>` URLs in generated RSS feeds) from `$HOSTNAME` unconditionally, every time the container starts:
```bash
export SERVER_URL=${HOSTNAME}
```
The comment above it says this is meant to capture the user's `HOSTNAME` value "before Docker overwrites it" â€” but some container runtimes/orchestration setups (rootless Podman under a systemd unit, per the reporter) set their own `HOSTNAME` (the container/pod name) in a way that can win over the user's `-e HOSTNAME=...` before this script ever runs. When that happens, every episode's RSS URL ends up built from the container name instead of the configured domain â€” exactly the `pinepods-pod/api/data/stream/...` output in the issue.

Worse, this line has no fallback logic, so it also clobbers `SERVER_URL` even if a user works around the problem by setting `SERVER_URL` directly (which `extract_domain_from_request` already prefers over `HOSTNAME`) â€” there was no way to actually fix this from the compose file before this change.

Fix: only fall back to `$HOSTNAME` when `SERVER_URL` isn't already set â€” `export SERVER_URL=${SERVER_URL:-$HOSTNAME}`. Zero behavior change for every existing install that isn't hitting this (still falls back to `HOSTNAME` exactly as before); an explicitly-set `SERVER_URL` is now actually honored. Also added a troubleshooting callout in the README Quick Start pointing anyone who sees this symptom at the `SERVER_URL` workaround.

**Verification:** `bash -n` on the script; manually exercised the `${SERVER_URL:-$HOSTNAME}` fallback logic in isolation for both the "unset" and "already set" cases; traced the full data path from `SERVER_URL` through `extract_domain_from_request` and `generate_podcast_rss`/`get_rss_episodes` to the RSS XML output. Not verified: no Podman/Docker instance available to me to reproduce the exact runtime-level `HOSTNAME` override end-to-end â€” happy to have the reporter (who has a reproducing setup) confirm before merge.
