### PR TITLE
Mobile: add unit test coverage for core utilities and entity models

### DIFF
--- a/mobile/test/core/date_utils_test.dart
+++ b/mobile/test/core/date_utils_test.dart
@@ -1,0 +1,126 @@
+// Regression tests for the pubdate parsing/formatting helpers. The backend
+// serializes pubdates as naive UTC strings, and these helpers must
+// reinterpret them as UTC (not device-local) before converting - getting
+// this wrong silently shifts every displayed date by the device's UTC
+// offset, so it's worth pinning down precisely.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/core/date_utils.dart';
+
+void main() {
+  group('parseEpisodePubDateLocal', () {
+    test('returns null for an empty string', () {
+      expect(parseEpisodePubDateLocal(''), isNull);
+    });
+
+    test('returns null for an unparsable string', () {
+      expect(parseEpisodePubDateLocal('not a date'), isNull);
+    });
+
+    test('reinterprets a naive (no offset) string as UTC before converting to local', () {
+      final result = parseEpisodePubDateLocal('2024-01-15T14:30:00');
+
+      final expected = DateTime.utc(2024, 1, 15, 14, 30, 0).toLocal();
+      expect(result, expected);
+    });
+
+    test('converts a string that already carries an explicit UTC designator', () {
+      final result = parseEpisodePubDateLocal('2024-01-15T14:30:00Z');
+
+      final expected = DateTime.utc(2024, 1, 15, 14, 30, 0).toLocal();
+      expect(result, expected);
+    });
+
+    test('converts a string with an explicit non-UTC offset', () {
+      final result = parseEpisodePubDateLocal('2024-01-15T14:30:00+05:00');
+
+      // 14:30 at +05:00 is 09:30 UTC.
+      final expected = DateTime.utc(2024, 1, 15, 9, 30, 0).toLocal();
+      expect(result, expected);
+    });
+  });
+
+  group('calendarDaysAgo', () {
+    test('is 0 for the same calendar day regardless of time of day', () {
+      final morning = DateTime(2024, 7, 10, 1, 0);
+      final night = DateTime(2024, 7, 10, 23, 59);
+
+      expect(calendarDaysAgo(morning, now: night), 0);
+    });
+
+    test('is 1 for yesterday even if less than 24 wall-clock hours apart', () {
+      final lateYesterday = DateTime(2024, 7, 9, 23, 0);
+      final earlyToday = DateTime(2024, 7, 10, 1, 0);
+
+      expect(calendarDaysAgo(lateYesterday, now: earlyToday), 1);
+    });
+
+    test('counts whole calendar days for dates further in the past', () {
+      // Deliberately mid-year (not March/April or October/November) so this
+      // doesn't straddle a DST transition in the host's local timezone,
+      // which would otherwise make the raw Duration between the two local
+      // midnights 23 or 25 hours short/long of a whole number of days.
+      final past = DateTime(2024, 7, 1);
+      final now = DateTime(2024, 7, 15);
+
+      expect(calendarDaysAgo(past, now: now), 14);
+    });
+
+    test('is negative for a date in the future', () {
+      final future = DateTime(2024, 7, 20);
+      final now = DateTime(2024, 7, 15);
+
+      expect(calendarDaysAgo(future, now: now), -5);
+    });
+  });
+
+  group('relativePubDateLabel', () {
+    test('returns the original string unchanged when unparsable', () {
+      expect(relativePubDateLabel('garbage'), 'garbage');
+    });
+
+    test('labels today as Today', () {
+      final now = DateTime.now();
+      final pubdate =
+          '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}T00:00:00';
+
+      // Using a naive string means it's reinterpreted as UTC then converted
+      // to local, so depending on the host's UTC offset this lands on
+      // either the same local calendar day (positive offsets) or the
+      // previous one (negative offsets, e.g. the Americas) - both are
+      // correct outcomes of the reinterpretation this helper exists to do.
+      expect(relativePubDateLabel(pubdate), anyOf('Today', 'Yesterday'));
+    });
+
+    test('labels a date within the last week as "N days ago"', () {
+      // toUtc().toIso8601String() carries an explicit 'Z', so this round-trips
+      // through parseEpisodePubDateLocal losslessly - no reinterpretation
+      // ambiguity, unlike the naive-string case above.
+      final threeDaysAgo = DateTime.now().subtract(const Duration(days: 3));
+      final pubdate = threeDaysAgo.toUtc().toIso8601String();
+
+      expect(relativePubDateLabel(pubdate), '3 days ago');
+    });
+
+    test('labels a date a few weeks ago as "N weeks ago"', () {
+      final twoWeeksAgo = DateTime.now().subtract(const Duration(days: 15));
+      final pubdate = twoWeeksAgo.toUtc().toIso8601String();
+
+      expect(relativePubDateLabel(pubdate), '2 weeks ago');
+    });
+
+    test('labels exactly one week ago as singular "1 week ago"', () {
+      final oneWeekAgo = DateTime.now().subtract(const Duration(days: 8));
+      final pubdate = oneWeekAgo.toUtc().toIso8601String();
+
+      expect(relativePubDateLabel(pubdate), '1 week ago');
+    });
+
+    test('labels a date over a month ago as "N months ago"', () {
+      final twoMonthsAgo = DateTime.now().subtract(const Duration(days: 65));
+      final pubdate = twoMonthsAgo.toUtc().toIso8601String();
+
+      expect(relativePubDateLabel(pubdate), '2 months ago');
+    });
+  });
+}

--- a/mobile/test/core/extensions_test.dart
+++ b/mobile/test/core/extensions_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/core/extensions.dart';
+
+void main() {
+  group('IterableExtensions.chunk', () {
+    test('splits a list into equal-sized chunks', () {
+      final result = [1, 2, 3, 4, 5, 6].chunk(2).toList();
+
+      expect(result, [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ]);
+    });
+
+    test('the last chunk can be smaller than the requested size', () {
+      final result = [1, 2, 3, 4, 5].chunk(2).toList();
+
+      expect(result, [
+        [1, 2],
+        [3, 4],
+        [5],
+      ]);
+    });
+
+    test('yields a single empty chunk for an empty iterable', () {
+      final result = <int>[].chunk(3).toList();
+
+      expect(result, [[]]);
+    });
+
+    test('a chunk size larger than the list returns everything as one chunk', () {
+      final result = [1, 2, 3].chunk(10).toList();
+
+      expect(result, [
+        [1, 2, 3],
+      ]);
+    });
+  });
+
+  group('ExtString.forceHttps', () {
+    test('upgrades a plain http URL to https', () {
+      expect('http://example.com/feed.xml'.forceHttps, 'https://example.com/feed.xml');
+    });
+
+    test('leaves an already-https URL unchanged', () {
+      expect('https://example.com/feed.xml'.forceHttps, 'https://example.com/feed.xml');
+    });
+
+    test('leaves localhost over http unchanged, to support self-hosted development', () {
+      expect('http://localhost:8040/api'.forceHttps, 'http://localhost:8040/api');
+    });
+
+    test('leaves 127.0.0.1 over http unchanged', () {
+      expect('http://127.0.0.1:8040/api'.forceHttps, 'http://127.0.0.1:8040/api');
+    });
+
+    test('leaves private 10.x addresses over http unchanged', () {
+      expect('http://10.0.1.5:8040/api'.forceHttps, 'http://10.0.1.5:8040/api');
+    });
+
+    test('leaves private 192.168.x addresses over http unchanged', () {
+      expect('http://192.168.1.50/api'.forceHttps, 'http://192.168.1.50/api');
+    });
+
+    test('leaves private 172.x addresses over http unchanged', () {
+      expect('http://172.16.0.5/api'.forceHttps, 'http://172.16.0.5/api');
+    });
+
+    test('leaves .local hostnames over http unchanged', () {
+      expect('http://pinepods.local/api'.forceHttps, 'http://pinepods.local/api');
+    });
+
+    test('is case-insensitive when matching the local-network exceptions', () {
+      expect('http://PINEPODS.LOCAL/api'.forceHttps, 'http://PINEPODS.LOCAL/api');
+    });
+
+    test('returns an empty string for null', () {
+      String? value;
+      expect(value.forceHttps, '');
+    });
+
+    test('leaves a non-http scheme (e.g. a relative path) unchanged', () {
+      expect('/relative/path'.forceHttps, '/relative/path');
+    });
+  });
+
+  group('ExtDouble.toTenth', () {
+    test('rounds to one decimal place', () {
+      expect(1.23.toTenth, 1.2);
+      expect(1.26.toTenth, 1.3);
+    });
+
+    test('leaves a value already at one decimal place unchanged', () {
+      expect(1.5.toTenth, 1.5);
+    });
+
+    test('rounds a whole number to itself', () {
+      expect(2.0.toTenth, 2.0);
+    });
+  });
+}

--- a/mobile/test/core/utils_test.dart
+++ b/mobile/test/core/utils_test.dart
@@ -1,0 +1,37 @@
+// Only covers the pure string-sanitizing helpers in core/utils.dart. The
+// rest of that file (resolvePath, getStorageDirectory, hasStoragePermission,
+// resolveUrl, etc.) talks to platform channels, the filesystem, or the
+// network, so it's out of scope for plain unit tests.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/core/utils.dart';
+
+void main() {
+  group('safePath', () {
+    test('strips characters invalid in file/directory names', () {
+      expect(safePath('My Podcast: The Sequel!'), 'My Podcast The Sequel');
+    });
+
+    test('leaves alphanumeric and spaces untouched', () {
+      expect(safePath('My Podcast 2'), 'My Podcast 2');
+    });
+
+    test('trims leading/trailing whitespace left behind by stripping', () {
+      expect(safePath('  Podcast?  '), 'Podcast');
+    });
+
+    test('returns null for null input', () {
+      expect(safePath(null), isNull);
+    });
+  });
+
+  group('safeFile', () {
+    test('strips invalid characters but keeps dots for file extensions', () {
+      expect(safeFile('episode: title!.mp3'), 'episode title.mp3');
+    });
+
+    test('returns null for null input', () {
+      expect(safeFile(null), isNull);
+    });
+  });
+}

--- a/mobile/test/entities/app_settings_test.dart
+++ b/mobile/test/entities/app_settings_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/app_settings.dart';
+
+void main() {
+  group('sensibleDefaults', () {
+    test('produces a usable dark-theme, iTunes-search, no-account default state', () {
+      final settings = AppSettings.sensibleDefaults();
+
+      expect(settings.theme, 'Dark');
+      expect(settings.searchProvider, 'itunes');
+      expect(settings.playbackSpeed, 1.0);
+      expect(settings.autoUpdateEpisodePeriod, -1);
+      expect(settings.showFunding, isTrue);
+      expect(settings.pinepodsServer, isNull);
+      expect(settings.pinepodsUserId, isNull);
+      expect(settings.bottomBarOrder, isNotEmpty);
+    });
+  });
+
+  group('copyWith', () {
+    test('overrides only the specified fields, keeping the rest', () {
+      final base = AppSettings.sensibleDefaults();
+
+      final updated = base.copyWith(theme: 'Light', pinepodsUserId: 42);
+
+      expect(updated.theme, 'Light');
+      expect(updated.pinepodsUserId, 42);
+      // Untouched fields carry over from the original.
+      expect(updated.searchProvider, base.searchProvider);
+      expect(updated.playbackSpeed, base.playbackSpeed);
+      expect(updated.bottomBarOrder, base.bottomBarOrder);
+    });
+
+    test('calling copyWith with no arguments returns an equivalent settings object', () {
+      final base = AppSettings.sensibleDefaults();
+      final copy = base.copyWith();
+
+      expect(copy.theme, base.theme);
+      expect(copy.pinepodsServer, base.pinepodsServer);
+      expect(copy.bottomBarOrder, base.bottomBarOrder);
+    });
+  });
+}

--- a/mobile/test/entities/chapter_test.dart
+++ b/mobile/test/entities/chapter_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/chapter.dart';
+
+void main() {
+  group('construction', () {
+    test('upgrades http image/url to https', () {
+      final chapter = Chapter(
+        title: 'Intro',
+        imageUrl: 'http://example.com/chapter.png',
+        url: 'http://example.com',
+        startTime: 0,
+      );
+
+      expect(chapter.imageUrl, 'https://example.com/chapter.png');
+      expect(chapter.url, 'https://example.com');
+    });
+  });
+
+  group('toMap/fromMap', () {
+    test('round-trips title, times, and the table-of-contents flag', () {
+      final original = Chapter(
+        title: 'Chapter One',
+        imageUrl: 'https://example.com/art.png',
+        url: 'https://example.com',
+        startTime: 30.5,
+        endTime: 120.0,
+        toc: false,
+      );
+
+      final restored = Chapter.fromMap(original.toMap());
+
+      expect(restored.title, original.title);
+      expect(restored.imageUrl, original.imageUrl);
+      expect(restored.url, original.url);
+      expect(restored.startTime, original.startTime);
+      expect(restored.endTime, original.endTime);
+      expect(restored.toc, isFalse);
+    });
+
+    test('toc defaults to true unless the stored value is exactly "false"', () {
+      final restored = Chapter.fromMap({'title': 'T', 'imageUrl': null, 'startTime': '0'});
+      expect(restored.toc, isTrue);
+    });
+  });
+
+  group('equality', () {
+    test('chapters with the same title and startTime are equal', () {
+      final a = Chapter(title: 'Intro', imageUrl: null, startTime: 0);
+      final b = Chapter(title: 'Intro', imageUrl: null, startTime: 0);
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('chapters with a different startTime are not equal', () {
+      final a = Chapter(title: 'Intro', imageUrl: null, startTime: 0);
+      final b = Chapter(title: 'Intro', imageUrl: null, startTime: 30);
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/test/entities/downloadable_test.dart
+++ b/mobile/test/entities/downloadable_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/downloadable.dart';
+
+void main() {
+  group('toMap/fromMap', () {
+    test('round-trips every field', () {
+      final original = Downloadable(
+        guid: 'guid-1',
+        url: 'https://example.com/episode.mp3',
+        directory: '/storage/podcast',
+        filename: 'episode.mp3',
+        taskId: 'task-1',
+        state: DownloadState.downloading,
+        percentage: 42,
+      );
+
+      final restored = Downloadable.fromMap(original.toMap());
+
+      expect(restored.guid, original.guid);
+      expect(restored.url, original.url);
+      expect(restored.directory, original.directory);
+      expect(restored.filename, original.filename);
+      expect(restored.taskId, original.taskId);
+      expect(restored.state, original.state);
+      expect(restored.percentage, original.percentage);
+    });
+
+    test('maps every DownloadState index round-trip', () {
+      for (final state in DownloadState.values) {
+        final original = Downloadable(
+          guid: 'g',
+          url: 'u',
+          directory: 'd',
+          filename: 'f',
+          taskId: 't',
+          state: state,
+          percentage: 0,
+        );
+
+        final restored = Downloadable.fromMap(original.toMap());
+
+        expect(restored.state, state, reason: 'failed for $state');
+      }
+    });
+  });
+
+  group('equality', () {
+    test('two downloadables with the same guid are equal regardless of other fields', () {
+      final a = Downloadable(guid: 'g', url: 'u1', directory: 'd1', filename: 'f1', taskId: 't1', state: DownloadState.none);
+      final b = Downloadable(guid: 'g', url: 'u2', directory: 'd2', filename: 'f2', taskId: 't2', state: DownloadState.downloaded);
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('downloadables with different guids are not equal', () {
+      final a = Downloadable(guid: 'g1', url: 'u', directory: 'd', filename: 'f', taskId: 't', state: DownloadState.none);
+      final b = Downloadable(guid: 'g2', url: 'u', directory: 'd', filename: 'f', taskId: 't', state: DownloadState.none);
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/test/entities/episode_test.dart
+++ b/mobile/test/entities/episode_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/downloadable.dart';
+import 'package:pinepods_mobile/entities/episode.dart';
+
+Episode _episode({
+  String guid = 'guid-1',
+  String? podcast = 'Some Podcast',
+  int position = 0,
+  int duration = 0,
+  int? downloadPercentage = 0,
+  String? description,
+  String? imageUrl,
+  String? contentUrl,
+}) {
+  return Episode(
+    guid: guid,
+    podcast: podcast,
+    position: position,
+    duration: duration,
+    downloadPercentage: downloadPercentage,
+    description: description,
+    imageUrl: imageUrl,
+    contentUrl: contentUrl,
+    // fromMap can't round-trip a null lastUpdated (toMap stores '' rather
+    // than a value fromMap's null-check recognizes), so give every episode
+    // built by this helper a concrete value to stay clear of that path. A
+    // fixed value (rather than DateTime.now()) keeps two separately-built
+    // episodes hashCode-equal, since hashCode (unlike ==) does factor in
+    // lastUpdated.
+    lastUpdated: DateTime(2024, 1, 1),
+  );
+}
+
+void main() {
+  group('construction', () {
+    test('upgrades http image/content URLs to https on construction', () {
+      final episode = _episode(
+        imageUrl: 'http://example.com/art.png',
+        contentUrl: 'http://example.com/episode.mp3',
+      );
+
+      expect(episode.imageUrl, 'https://example.com/art.png');
+      expect(episode.contentUrl, 'https://example.com/episode.mp3');
+    });
+
+    test('leaves a local-network content URL over http unchanged', () {
+      final episode = _episode(contentUrl: 'http://192.168.1.10:8040/episode.mp3');
+
+      expect(episode.contentUrl, 'http://192.168.1.10:8040/episode.mp3');
+    });
+  });
+
+  group('toMap/fromMap', () {
+    test('round-trips every field', () {
+      final original = Episode(
+        guid: 'guid-1',
+        pguid: 'podcast-guid',
+        podcast: 'Some Podcast',
+        downloadTaskId: 'task-1',
+        filepath: '/storage/podcast',
+        filename: 'episode.mp3',
+        downloadState: DownloadState.downloaded,
+        title: 'Episode Title',
+        description: '<p>desc</p>',
+        content: 'content',
+        link: 'https://example.com',
+        imageUrl: 'https://example.com/art.png',
+        publicationDate: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        contentUrl: 'https://example.com/episode.mp3',
+        author: 'Author',
+        season: 2,
+        episode: 5,
+        duration: 3600,
+        position: 120,
+        downloadPercentage: 100,
+        played: true,
+        lastUpdated: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+      );
+
+      final restored = Episode.fromMap(42, original.toMap());
+
+      expect(restored.id, 42);
+      expect(restored.guid, original.guid);
+      expect(restored.pguid, original.pguid);
+      expect(restored.downloadTaskId, original.downloadTaskId);
+      expect(restored.filepath, original.filepath);
+      expect(restored.filename, original.filename);
+      expect(restored.downloadState, original.downloadState);
+      expect(restored.podcast, original.podcast);
+      expect(restored.title, original.title);
+      expect(restored.description, original.description);
+      expect(restored.content, original.content);
+      expect(restored.link, original.link);
+      expect(restored.imageUrl, original.imageUrl);
+      expect(restored.publicationDate, original.publicationDate);
+      expect(restored.contentUrl, original.contentUrl);
+      expect(restored.author, original.author);
+      expect(restored.season, original.season);
+      expect(restored.episode, original.episode);
+      expect(restored.duration, original.duration);
+      expect(restored.position, original.position);
+      expect(restored.downloadPercentage, original.downloadPercentage);
+      expect(restored.played, original.played);
+      expect(restored.lastUpdated, original.lastUpdated);
+    });
+
+    test('defaults numeric fields to 0 and a fresh date when absent', () {
+      final map = <String, dynamic>{
+        'guid': 'guid-1',
+        'podcast': 'Some Podcast',
+      };
+
+      final restored = Episode.fromMap(1, map);
+
+      expect(restored.season, 0);
+      expect(restored.episode, 0);
+      expect(restored.duration, 0);
+      expect(restored.position, 0);
+      expect(restored.downloadPercentage, 0);
+      expect(restored.played, isFalse);
+      expect(restored.publicationDate, isNotNull);
+    });
+
+    test('maps every DownloadState index round-trip through toMap/fromMap', () {
+      for (final state in DownloadState.values) {
+        final original = _episode()..downloadState = state;
+        final restored = Episode.fromMap(1, original.toMap());
+
+        expect(restored.downloadState, state, reason: 'failed for $state');
+      }
+    });
+  });
+
+  group('equality', () {
+    test('two episodes with the same field values are equal', () {
+      final a = _episode(guid: 'guid-1');
+      final b = _episode(guid: 'guid-1');
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('episodes with a different guid are not equal', () {
+      final a = _episode(guid: 'guid-1');
+      final b = _episode(guid: 'guid-2');
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('downloaded', () {
+    test('is true only at exactly 100%', () {
+      expect(_episode(downloadPercentage: 100).downloaded, isTrue);
+      expect(_episode(downloadPercentage: 99).downloaded, isFalse);
+      expect(_episode(downloadPercentage: null).downloaded, isFalse);
+    });
+  });
+
+  group('timeRemaining', () {
+    test('is zero when there is no position yet', () {
+      expect(_episode(position: 0, duration: 600).timeRemaining, Duration.zero);
+    });
+
+    test('is zero when duration is unknown', () {
+      expect(_episode(position: 1000, duration: 0).timeRemaining, Duration.zero);
+    });
+
+    test('is duration (seconds) minus position (ms treated as seconds component)', () {
+      // position is stored in milliseconds; timeRemaining takes the seconds
+      // component of that as elapsed seconds against a duration in seconds.
+      final episode = _episode(position: 30000, duration: 600);
+      expect(episode.timeRemaining, const Duration(seconds: 570));
+    });
+  });
+
+  group('percentagePlayed', () {
+    test('is zero with no position or duration', () {
+      expect(_episode(position: 0, duration: 600).percentagePlayed, 0.0);
+    });
+
+    test('computes position (ms) over duration (seconds) as a percentage', () {
+      final episode = _episode(position: 30000, duration: 60);
+      expect(episode.percentagePlayed, 50.0);
+    });
+
+    test('clamps at 100 even if position implies more than the full duration', () {
+      final episode = _episode(position: 999999, duration: 10);
+      expect(episode.percentagePlayed, 100.0);
+    });
+  });
+
+  group('descriptionText', () {
+    test('is empty when there is no description', () {
+      expect(_episode(description: null).descriptionText, '');
+    });
+
+    test('strips HTML tags down to plain text', () {
+      final episode = _episode(description: '<p>Hello <b>world</b></p>');
+      expect(episode.descriptionText, 'Hello world');
+    });
+
+    test('replaces <br> tags with a space for readability', () {
+      final episode = _episode(description: 'Line one<br/>Line two');
+      expect(episode.descriptionText, 'Line one Line two');
+    });
+  });
+
+  group('hasChapters / hasTranscripts', () {
+    test('hasChapters is false with no chaptersUrl and no chapters', () {
+      expect(_episode().hasChapters, isFalse);
+    });
+
+    test('hasChapters is true when chaptersUrl is set', () {
+      final episode = Episode(guid: 'g', podcast: 'p', chaptersUrl: 'https://example.com/chapters.json');
+      expect(episode.hasChapters, isTrue);
+    });
+
+    test('hasTranscripts is false with no transcript URLs', () {
+      expect(_episode().hasTranscripts, isFalse);
+    });
+  });
+
+  group('chaptersAreLoaded / chaptersAreNotLoaded', () {
+    test('neither is true before loading has been attempted', () {
+      final episode = _episode();
+      expect(episode.chaptersAreLoaded, isFalse);
+      expect(episode.chaptersAreNotLoaded, isFalse);
+    });
+
+    test('chaptersAreNotLoaded is true while loading with nothing loaded yet', () {
+      final episode = _episode()..chaptersLoading = true;
+      expect(episode.chaptersAreNotLoaded, isTrue);
+      expect(episode.chaptersAreLoaded, isFalse);
+    });
+  });
+
+  group('positionalImageUrl', () {
+    test('falls back to the episode image when there is no current chapter', () {
+      final episode = _episode(imageUrl: 'https://example.com/episode.png');
+      expect(episode.positionalImageUrl, 'https://example.com/episode.png');
+    });
+  });
+}

--- a/mobile/test/entities/funding_test.dart
+++ b/mobile/test/entities/funding_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/funding.dart';
+
+void main() {
+  test('upgrades an http funding URL to https on construction', () {
+    final funding = Funding(url: 'http://example.com/donate', value: 'Support the show');
+    expect(funding.url, 'https://example.com/donate');
+  });
+
+  group('toMap/fromMap', () {
+    test('round-trips url and value', () {
+      final original = Funding(url: 'https://example.com/donate', value: 'Support the show');
+      final restored = Funding.fromMap(original.toMap());
+
+      expect(restored.url, original.url);
+      expect(restored.value, original.value);
+    });
+  });
+}

--- a/mobile/test/entities/home_data_test.dart
+++ b/mobile/test/entities/home_data_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/home_data.dart';
+
+HomeEpisode _homeEpisode({
+  int episodeDuration = 600,
+  int? listenDuration,
+}) {
+  return HomeEpisode(
+    episodeId: 1,
+    podcastId: 1,
+    episodeTitle: 'Some Episode',
+    episodeDescription: 'Description',
+    episodeUrl: 'https://example.com/episode.mp3',
+    episodeArtwork: 'https://example.com/art.png',
+    episodePubDate: '2024-01-15T00:00:00Z',
+    episodeDuration: episodeDuration,
+    completed: false,
+    podcastName: 'Some Podcast',
+    isYoutube: false,
+    listenDuration: listenDuration,
+  );
+}
+
+void main() {
+  group('HomePodcast.fromJson', () {
+    test('parses categories given as the old string format', () {
+      final podcast = HomePodcast.fromJson({
+        'podcastid': 1,
+        'podcastname': 'Some Podcast',
+        'is_youtube': false,
+        'play_count': 0,
+        'categories': 'Comedy, News',
+      });
+
+      expect(podcast.categories, 'Comedy, News');
+    });
+
+    test('parses categories given as the newer map format into a comma-separated string', () {
+      final podcast = HomePodcast.fromJson({
+        'podcastid': 1,
+        'podcastname': 'Some Podcast',
+        'is_youtube': false,
+        'play_count': 0,
+        'categories': {'0': 'Comedy', '1': 'News'},
+      });
+
+      expect(podcast.categories, 'Comedy, News');
+    });
+
+    test('an empty categories map becomes null rather than an empty string', () {
+      final podcast = HomePodcast.fromJson({
+        'podcastid': 1,
+        'podcastname': 'Some Podcast',
+        'is_youtube': false,
+        'play_count': 0,
+        'categories': <String, dynamic>{},
+      });
+
+      expect(podcast.categories, isNull);
+    });
+
+    test('categories is null when the key is absent', () {
+      final podcast = HomePodcast.fromJson({
+        'podcastid': 1,
+        'podcastname': 'Some Podcast',
+        'is_youtube': false,
+        'play_count': 0,
+      });
+
+      expect(podcast.categories, isNull);
+    });
+
+    test('defaults missing required-ish fields rather than throwing', () {
+      final podcast = HomePodcast.fromJson(const {});
+
+      expect(podcast.podcastId, 0);
+      expect(podcast.podcastName, '');
+      expect(podcast.isYoutube, isFalse);
+      expect(podcast.playCount, 0);
+    });
+  });
+
+  group('HomeEpisode.fromJson', () {
+    test('reads every field', () {
+      final episode = HomeEpisode.fromJson({
+        'episodeid': 5,
+        'podcastid': 1,
+        'episodetitle': 'Title',
+        'episodedescription': 'Description',
+        'episodeurl': 'https://example.com/episode.mp3',
+        'episodeartwork': 'https://example.com/art.png',
+        'episodepubdate': '2024-01-15T00:00:00Z',
+        'episodeduration': 600,
+        'completed': true,
+        'podcastname': 'Some Podcast',
+        'is_youtube': false,
+        'listenduration': 120,
+        'saved': true,
+        'queued': true,
+        'downloaded': true,
+      });
+
+      expect(episode.episodeId, 5);
+      expect(episode.completed, isTrue);
+      expect(episode.saved, isTrue);
+      expect(episode.queued, isTrue);
+      expect(episode.downloaded, isTrue);
+      expect(episode.listenDuration, 120);
+    });
+  });
+
+  group('HomeEpisode.formattedDuration', () {
+    test('is placeholder dashes when duration is zero', () {
+      expect(_homeEpisode(episodeDuration: 0).formattedDuration, '--:--');
+    });
+
+    test('formats under an hour as MM:SS', () {
+      expect(_homeEpisode(episodeDuration: 125).formattedDuration, '02:05');
+    });
+
+    test('formats an hour or more as HH:MM:SS', () {
+      expect(_homeEpisode(episodeDuration: 3725).formattedDuration, '01:02:05');
+    });
+  });
+
+  group('HomeEpisode.formattedListenDuration', () {
+    test('is null with no listen duration', () {
+      expect(_homeEpisode(listenDuration: null).formattedListenDuration, isNull);
+    });
+
+    test('formats a listen duration under an hour', () {
+      expect(_homeEpisode(listenDuration: 65).formattedListenDuration, '01:05');
+    });
+  });
+
+  group('HomeEpisode.progressPercentage', () {
+    test('is 0 with no listen duration', () {
+      expect(_homeEpisode(episodeDuration: 600, listenDuration: null).progressPercentage, 0.0);
+    });
+
+    test('computes the percentage listened', () {
+      expect(_homeEpisode(episodeDuration: 200, listenDuration: 50).progressPercentage, 25.0);
+    });
+  });
+
+  group('WeeklyStats', () {
+    test('fromJson defaults missing fields to zero', () {
+      final stats = WeeklyStats.fromJson(const {});
+      expect(stats.secondsListened, 0);
+      expect(stats.episodesCompleted, 0);
+    });
+
+    test('hasActivity is false with nothing listened or completed', () {
+      expect(WeeklyStats().hasActivity, isFalse);
+    });
+
+    test('hasActivity is true with either seconds listened or episodes completed', () {
+      expect(WeeklyStats(secondsListened: 1).hasActivity, isTrue);
+      expect(WeeklyStats(episodesCompleted: 1).hasActivity, isTrue);
+    });
+
+    test('formattedListened shows minutes only under an hour', () {
+      expect(WeeklyStats(secondsListened: 29 * 60).formattedListened, '29m');
+    });
+
+    test('formattedListened shows hours and minutes once over an hour', () {
+      expect(WeeklyStats(secondsListened: 65 * 60).formattedListened, '1h 5m');
+    });
+  });
+
+  group('HomeOverview.fromJson', () {
+    test('parses nested episode and podcast lists, defaulting missing ones to empty', () {
+      final overview = HomeOverview.fromJson({
+        'recent_episodes': [
+          {'episodeid': 1, 'podcastid': 1, 'episodetitle': 'A', 'podcastname': 'P', 'episodepubdate': '', 'episodeduration': 0},
+        ],
+        'saved_count': 3,
+        'downloaded_count': 2,
+        'queue_count': 1,
+      });
+
+      expect(overview.recentEpisodes, hasLength(1));
+      expect(overview.inProgressEpisodes, isEmpty);
+      expect(overview.queuePreview, isEmpty);
+      expect(overview.topPodcasts, isEmpty);
+      expect(overview.savedCount, 3);
+      expect(overview.downloadedCount, 2);
+      expect(overview.queueCount, 1);
+      expect(overview.weeklyStats.hasActivity, isFalse);
+    });
+  });
+
+  group('Playlist/PlaylistResponse.fromJson', () {
+    test('Playlist.fromJson reads fields and defaults iconName', () {
+      final playlist = Playlist.fromJson({'playlist_id': 1, 'name': 'My Playlist'});
+
+      expect(playlist.playlistId, 1);
+      expect(playlist.name, 'My Playlist');
+      expect(playlist.iconName, 'ph-music-notes');
+    });
+
+    test('PlaylistResponse.fromJson parses a list of playlists', () {
+      final response = PlaylistResponse.fromJson({
+        'playlists': [
+          {'playlist_id': 1, 'name': 'A'},
+          {'playlist_id': 2, 'name': 'B'},
+        ],
+      });
+
+      expect(response.playlists, hasLength(2));
+      expect(response.playlists[1].name, 'B');
+    });
+
+    test('PlaylistResponse.fromJson defaults to an empty list when absent', () {
+      final response = PlaylistResponse.fromJson(const {});
+      expect(response.playlists, isEmpty);
+    });
+  });
+}

--- a/mobile/test/entities/pending_action_test.dart
+++ b/mobile/test/entities/pending_action_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/pending_action.dart';
+
+void main() {
+  group('toMap/fromMap', () {
+    test('round-trips every field', () {
+      // createdAt is stored as whole milliseconds, so use a value with no
+      // sub-millisecond component - DateTime.now() has microsecond
+      // resolution and would make an exact round-trip comparison flaky.
+      final createdAt = DateTime(2024, 1, 1, 12, 0, 0);
+      final original = PendingAction(
+        type: PendingActionType.recordPosition,
+        episodeId: 101,
+        userId: 42,
+        isYoutube: true,
+        payload: const {'position': 123.0},
+        createdAt: createdAt,
+        retryCount: 2,
+      );
+
+      final restored = PendingAction.fromMap(9, original.toMap());
+
+      expect(restored.id, 9);
+      expect(restored.type, PendingActionType.recordPosition);
+      expect(restored.episodeId, 101);
+      expect(restored.userId, 42);
+      expect(restored.isYoutube, isTrue);
+      expect(restored.payload, {'position': 123.0});
+      expect(restored.retryCount, 2);
+      expect(restored.createdAt, createdAt);
+    });
+
+    test('every action type round-trips through its stored name', () {
+      for (final type in PendingActionType.values) {
+        final original = PendingAction(type: type, episodeId: 1, userId: 1);
+        final restored = PendingAction.fromMap(1, original.toMap());
+
+        expect(restored.type, type, reason: 'failed for $type');
+      }
+    });
+
+    test('an unrecognized stored type name falls back to recordPosition', () {
+      final restored = PendingAction.fromMap(1, {'type': 'somethingUnknown', 'episodeId': 1, 'userId': 1});
+      expect(restored.type, PendingActionType.recordPosition);
+    });
+
+    test('missing episodeId/userId default to 0 rather than throwing', () {
+      final restored = PendingAction.fromMap(1, const {'type': 'saveEpisode'});
+      expect(restored.episodeId, 0);
+      expect(restored.userId, 0);
+      expect(restored.retryCount, 0);
+    });
+  });
+
+  group('position', () {
+    test('reads the numeric position out of the payload', () {
+      final action = PendingAction(
+        type: PendingActionType.recordPosition,
+        episodeId: 1,
+        userId: 1,
+        payload: const {'position': 45.5},
+      );
+
+      expect(action.position, 45.5);
+    });
+
+    test('is null when the payload has no position entry', () {
+      final action = PendingAction(type: PendingActionType.markCompleted, episodeId: 1, userId: 1);
+      expect(action.position, isNull);
+    });
+  });
+
+  group('description', () {
+    test('describes a recordPosition action with its position when known', () {
+      final action = PendingAction(
+        type: PendingActionType.recordPosition,
+        episodeId: 1,
+        userId: 1,
+        payload: const {'position': 30.0},
+      );
+
+      expect(action.description, 'Save progress (30s)');
+    });
+
+    test('describes a recordPosition action generically when no position is set', () {
+      final action = PendingAction(type: PendingActionType.recordPosition, episodeId: 1, userId: 1);
+      expect(action.description, 'Save progress');
+    });
+
+    test('has a human-readable description for every action type', () {
+      final expected = {
+        PendingActionType.markCompleted: 'Mark completed',
+        PendingActionType.markUncompleted: 'Mark not completed',
+        PendingActionType.saveEpisode: 'Save episode',
+        PendingActionType.removeSaved: 'Remove saved episode',
+        PendingActionType.queue: 'Add to queue',
+        PendingActionType.addHistory: 'Add to history',
+      };
+
+      expected.forEach((type, label) {
+        final action = PendingAction(type: type, episodeId: 1, userId: 1);
+        expect(action.description, label, reason: 'failed for $type');
+      });
+    });
+  });
+}

--- a/mobile/test/entities/persistable_test.dart
+++ b/mobile/test/entities/persistable_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/persistable.dart';
+
+void main() {
+  group('empty', () {
+    test('produces a not-yet-played placeholder', () {
+      final persistable = Persistable.empty();
+
+      expect(persistable.pguid, '');
+      expect(persistable.episodeId, 0);
+      expect(persistable.position, 0);
+      expect(persistable.state, LastState.none);
+    });
+  });
+
+  group('toMap/fromMap', () {
+    test('round-trips pguid, episodeId, and position', () {
+      final original = Persistable(
+        pguid: 'podcast-guid',
+        episodeId: 42,
+        position: 120,
+        state: LastState.paused,
+        lastUpdated: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+      );
+
+      final restored = Persistable.fromMap(original.toMap());
+
+      expect(restored.pguid, 'podcast-guid');
+      expect(restored.episodeId, 42);
+      expect(restored.position, 120);
+      expect(restored.lastUpdated, original.lastUpdated);
+    });
+
+    test('every playback state round-trips through its stored string', () {
+      for (final state in LastState.values) {
+        final original = Persistable(pguid: 'g', episodeId: 1, position: 0, state: state);
+        final restored = Persistable.fromMap(original.toMap());
+
+        expect(restored.state, state, reason: 'failed for $state');
+      }
+    });
+  });
+}

--- a/mobile/test/entities/person_test.dart
+++ b/mobile/test/entities/person_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/person.dart';
+
+void main() {
+  group('construction', () {
+    test('upgrades http image/link to https', () {
+      final person = Person(name: 'Host', image: 'http://example.com/host.png', link: 'http://example.com');
+
+      expect(person.image, 'https://example.com/host.png');
+      expect(person.link, 'https://example.com');
+    });
+
+    test('role and group default to an empty string', () {
+      final person = Person(name: 'Host');
+
+      expect(person.role, '');
+      expect(person.group, '');
+    });
+  });
+
+  group('toMap/fromMap', () {
+    test('round-trips every field', () {
+      final original = Person(name: 'Host', role: 'host', group: 'cast', image: 'https://example.com/host.png', link: 'https://example.com');
+
+      final restored = Person.fromMap(original.toMap());
+
+      expect(restored, original);
+      expect(restored.name, 'Host');
+      expect(restored.role, 'host');
+      expect(restored.group, 'cast');
+    });
+
+    test('missing fields default to an empty string rather than throwing', () {
+      final restored = Person.fromMap(const {});
+
+      expect(restored.name, '');
+      expect(restored.role, '');
+      expect(restored.group, '');
+    });
+  });
+
+  group('equality', () {
+    test('two persons with identical fields are equal', () {
+      final a = Person(name: 'Host', role: 'host');
+      final b = Person(name: 'Host', role: 'host');
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('persons with a different name are not equal', () {
+      final a = Person(name: 'Host A');
+      final b = Person(name: 'Host B');
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/test/entities/pinepods_episode_test.dart
+++ b/mobile/test/entities/pinepods_episode_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/pinepods_episode.dart';
+
+PinepodsEpisode _episode({
+  int episodeDuration = 600,
+  int? listenDuration,
+  String episodePubDate = '2024-01-15T14:30:00',
+}) {
+  return PinepodsEpisode(
+    podcastName: 'Some Podcast',
+    episodeTitle: 'Some Episode',
+    episodePubDate: episodePubDate,
+    episodeDescription: 'Description',
+    episodeArtwork: 'https://example.com/art.png',
+    episodeUrl: 'https://example.com/episode.mp3',
+    episodeDuration: episodeDuration,
+    listenDuration: listenDuration,
+    episodeId: 101,
+    completed: false,
+    saved: false,
+    queued: false,
+    downloaded: false,
+    isYoutube: false,
+  );
+}
+
+void main() {
+  group('fromJson', () {
+    test('reads capitalized keys (as returned by the PinePods API)', () {
+      final episode = PinepodsEpisode.fromJson({
+        'Podcastname': 'Some Podcast',
+        'Episodetitle': 'Some Episode',
+        'Episodepubdate': '2024-01-15T14:30:00',
+        'Episodedescription': 'Description',
+        'Episodeartwork': 'https://example.com/art.png',
+        'Episodeurl': 'https://example.com/episode.mp3',
+        'Episodeduration': 600,
+        'Listenduration': 120,
+        'Episodeid': 101,
+        'Completed': true,
+        'Saved': true,
+        'Queued': true,
+        'Downloaded': true,
+        'Is_youtube': true,
+        'Podcastid': 7,
+      });
+
+      expect(episode.podcastName, 'Some Podcast');
+      expect(episode.episodeTitle, 'Some Episode');
+      expect(episode.episodeDuration, 600);
+      expect(episode.listenDuration, 120);
+      expect(episode.episodeId, 101);
+      expect(episode.completed, isTrue);
+      expect(episode.saved, isTrue);
+      expect(episode.queued, isTrue);
+      expect(episode.downloaded, isTrue);
+      expect(episode.isYoutube, isTrue);
+      expect(episode.podcastId, 7);
+    });
+
+    test('falls back to lowercase keys', () {
+      final episode = PinepodsEpisode.fromJson({
+        'podcastname': 'Some Podcast',
+        'episodetitle': 'Some Episode',
+        'episodepubdate': '2024-01-15T14:30:00',
+        'episodedescription': 'Description',
+        'episodeartwork': 'https://example.com/art.png',
+        'episodeurl': 'https://example.com/episode.mp3',
+        'episodeduration': 600,
+        'listenduration': 120,
+        'episodeid': 101,
+        'completed': true,
+        'saved': false,
+        'queued': false,
+        'downloaded': false,
+        'is_youtube': false,
+      });
+
+      expect(episode.podcastName, 'Some Podcast');
+      expect(episode.listenDuration, 120);
+      expect(episode.completed, isTrue);
+    });
+
+    test('defaults missing fields to empty/zero/false rather than throwing', () {
+      final episode = PinepodsEpisode.fromJson(const {});
+
+      expect(episode.podcastName, '');
+      expect(episode.episodeTitle, '');
+      expect(episode.episodeDuration, 0);
+      expect(episode.listenDuration, isNull);
+      expect(episode.episodeId, 0);
+      expect(episode.completed, isFalse);
+      expect(episode.podcastId, isNull);
+    });
+  });
+
+  group('toJson', () {
+    test('serializes back to the lowercase key format', () {
+      final episode = _episode(listenDuration: 30);
+
+      final json = episode.toJson();
+
+      expect(json['podcastname'], 'Some Podcast');
+      expect(json['listenduration'], 30);
+      expect(json['is_youtube'], isFalse);
+    });
+  });
+
+  group('formattedDuration', () {
+    test('is 0:00 when duration is zero or negative', () {
+      expect(_episode(episodeDuration: 0).formattedDuration, '0:00');
+    });
+
+    test('formats under an hour as M:SS', () {
+      expect(_episode(episodeDuration: 125).formattedDuration, '2:05');
+    });
+
+    test('formats an hour or more as H:MM:SS', () {
+      expect(_episode(episodeDuration: 3725).formattedDuration, '1:02:05');
+    });
+  });
+
+  group('progressPercentage', () {
+    test('is 0 when there is no listen duration yet', () {
+      expect(_episode(episodeDuration: 600, listenDuration: null).progressPercentage, 0.0);
+    });
+
+    test('computes the percentage listened', () {
+      expect(_episode(episodeDuration: 200, listenDuration: 50).progressPercentage, 25.0);
+    });
+
+    test('clamps at 100 even if listenDuration exceeds the episode duration', () {
+      expect(_episode(episodeDuration: 100, listenDuration: 500).progressPercentage, 100.0);
+    });
+  });
+
+  group('isStarted', () {
+    test('is false with no listen duration', () {
+      expect(_episode(listenDuration: null).isStarted, isFalse);
+    });
+
+    test('is false with a zero listen duration', () {
+      expect(_episode(listenDuration: 0).isStarted, isFalse);
+    });
+
+    test('is true once there is some listen duration', () {
+      expect(_episode(listenDuration: 1).isStarted, isTrue);
+    });
+  });
+
+  group('formattedListenDuration', () {
+    test('is 0:00 with no listen duration', () {
+      expect(_episode(listenDuration: null).formattedListenDuration, '0:00');
+    });
+
+    test('formats under an hour as M:SS', () {
+      expect(_episode(listenDuration: 65).formattedListenDuration, '1:05');
+    });
+
+    test('formats an hour or more as H:MM:SS', () {
+      expect(_episode(listenDuration: 3665).formattedListenDuration, '1:01:05');
+    });
+  });
+
+  group('formattedPubDate', () {
+    test('delegates to relativePubDateLabel and returns the raw string when unparsable', () {
+      expect(_episode(episodePubDate: 'not a date').formattedPubDate, 'not a date');
+    });
+  });
+}

--- a/mobile/test/entities/pinepods_search_test.dart
+++ b/mobile/test/entities/pinepods_search_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/pinepods_search.dart';
+
+PinepodsPodcast _pinepodsPodcast({int id = 1, String title = 'Some Podcast'}) {
+  return PinepodsPodcast(
+    id: id,
+    title: title,
+    url: 'https://example.com/feed.xml',
+    originalUrl: 'https://example.com/original.xml',
+    link: 'https://example.com',
+    description: 'A podcast',
+    author: 'Author',
+    ownerName: 'Owner',
+    image: 'https://example.com/art.png',
+    artwork: 'https://example.com/artwork.png',
+    lastUpdateTime: 1700000000,
+    explicit: false,
+    episodeCount: 42,
+  );
+}
+
+PinepodsITunesPodcast _itunesPodcast({
+  int trackId = 55,
+  List<String> genres = const ['Comedy', 'Tech'],
+  String releaseDate = '2024-01-15T00:00:00Z',
+  String collectionExplicitness = 'notExplicit',
+  int? trackCount = 10,
+}) {
+  return PinepodsITunesPodcast(
+    wrapperType: 'track',
+    kind: 'podcast',
+    collectionId: 999,
+    trackId: trackId,
+    artistName: 'Some Artist',
+    trackName: 'Some Show',
+    collectionViewUrl: 'https://podcasts.apple.com/show',
+    feedUrl: 'https://example.com/feed.xml',
+    artworkUrl100: 'https://example.com/art100.png',
+    releaseDate: releaseDate,
+    genres: genres,
+    collectionExplicitness: collectionExplicitness,
+    trackCount: trackCount,
+  );
+}
+
+void main() {
+  group('PinepodsPodcast.fromJson/toJson', () {
+    test('round-trips every field, including a categories map', () {
+      final json = {
+        'id': 1,
+        'title': 'Some Podcast',
+        'url': 'https://example.com/feed.xml',
+        'originalUrl': 'https://example.com/original.xml',
+        'link': 'https://example.com',
+        'description': 'A podcast',
+        'author': 'Author',
+        'ownerName': 'Owner',
+        'image': 'https://example.com/art.png',
+        'artwork': 'https://example.com/artwork.png',
+        'lastUpdateTime': 1700000000,
+        'categories': {'0': 'Comedy'},
+        'explicit': false,
+        'episodeCount': 42,
+      };
+
+      final podcast = PinepodsPodcast.fromJson(json);
+
+      expect(podcast.id, 1);
+      expect(podcast.title, 'Some Podcast');
+      expect(podcast.categories, {'0': 'Comedy'});
+      expect(podcast.episodeCount, 42);
+      expect(podcast.toJson(), json);
+    });
+
+    test('categories defaults to null when absent', () {
+      final podcast = _pinepodsPodcast();
+      expect(podcast.categories, isNull);
+    });
+  });
+
+  group('PinepodsITunesPodcast.fromJson/toJson', () {
+    test('round-trips every field, including the genres list', () {
+      final json = {
+        'wrapperType': 'track',
+        'kind': 'podcast',
+        'collectionId': 999,
+        'trackId': 55,
+        'artistName': 'Some Artist',
+        'trackName': 'Some Show',
+        'collectionViewUrl': 'https://podcasts.apple.com/show',
+        'feedUrl': 'https://example.com/feed.xml',
+        'artworkUrl100': 'https://example.com/art100.png',
+        'releaseDate': '2024-01-15T00:00:00Z',
+        'genres': ['Comedy', 'Tech'],
+        'collectionExplicitness': 'notExplicit',
+        'trackCount': 10,
+      };
+
+      final podcast = PinepodsITunesPodcast.fromJson(json);
+
+      expect(podcast.trackId, 55);
+      expect(podcast.genres, ['Comedy', 'Tech']);
+      expect(podcast.trackCount, 10);
+      expect(podcast.toJson(), json);
+    });
+
+    test('genres defaults to an empty list and trackCount to null when absent', () {
+      final podcast = PinepodsITunesPodcast.fromJson(const {});
+
+      expect(podcast.genres, isEmpty);
+      expect(podcast.trackCount, isNull);
+    });
+  });
+
+  group('UnifiedPinepodsPodcast.fromPodcast', () {
+    test('maps the podcast index id into indexId and zeroes the internal id', () {
+      final podcast = _pinepodsPodcast(id: 7, title: 'Indexed Show');
+
+      final unified = UnifiedPinepodsPodcast.fromPodcast(podcast);
+
+      expect(unified.id, 0);
+      expect(unified.indexId, 7);
+      expect(unified.title, 'Indexed Show');
+      expect(unified.url, podcast.url);
+      expect(unified.episodeCount, podcast.episodeCount);
+      expect(unified.categories, podcast.categories);
+    });
+  });
+
+  group('UnifiedPinepodsPodcast.fromITunesPodcast', () {
+    test('maps trackId to id, converts the genre list to an indexed map', () {
+      final podcast = _itunesPodcast(trackId: 123, genres: const ['Comedy', 'News']);
+
+      final unified = UnifiedPinepodsPodcast.fromITunesPodcast(podcast);
+
+      expect(unified.id, 123);
+      expect(unified.indexId, 0);
+      expect(unified.title, podcast.trackName);
+      expect(unified.categories, {'0': 'Comedy', '1': 'News'});
+      expect(unified.description, 'Descriptions not provided by iTunes');
+    });
+
+    test('parses a valid releaseDate into a unix-seconds timestamp', () {
+      final podcast = _itunesPodcast(releaseDate: '2024-01-01T00:00:00Z');
+
+      final unified = UnifiedPinepodsPodcast.fromITunesPodcast(podcast);
+
+      expect(unified.lastUpdateTime, DateTime.parse('2024-01-01T00:00:00Z').millisecondsSinceEpoch ~/ 1000);
+    });
+
+    test('falls back to a 0 timestamp when releaseDate cannot be parsed', () {
+      final podcast = _itunesPodcast(releaseDate: 'not a date');
+
+      final unified = UnifiedPinepodsPodcast.fromITunesPodcast(podcast);
+
+      expect(unified.lastUpdateTime, 0);
+    });
+
+    test('explicit is true only when collectionExplicitness is exactly "explicit"', () {
+      expect(UnifiedPinepodsPodcast.fromITunesPodcast(_itunesPodcast(collectionExplicitness: 'explicit')).explicit, isTrue);
+      expect(UnifiedPinepodsPodcast.fromITunesPodcast(_itunesPodcast(collectionExplicitness: 'notExplicit')).explicit, isFalse);
+      expect(UnifiedPinepodsPodcast.fromITunesPodcast(_itunesPodcast(collectionExplicitness: 'cleaned')).explicit, isFalse);
+    });
+
+    test('episodeCount falls back to 0 when trackCount is null', () {
+      final podcast = _itunesPodcast(trackCount: null);
+      expect(UnifiedPinepodsPodcast.fromITunesPodcast(podcast).episodeCount, 0);
+    });
+  });
+
+  group('UnifiedPinepodsPodcast.fromJson/toJson', () {
+    test('round-trips every field', () {
+      final json = {
+        'id': 1,
+        'indexId': 2,
+        'title': 'T',
+        'url': 'https://example.com/feed.xml',
+        'originalUrl': 'https://example.com/original.xml',
+        'link': 'https://example.com',
+        'description': 'D',
+        'author': 'A',
+        'ownerName': 'O',
+        'image': 'https://example.com/art.png',
+        'artwork': 'https://example.com/artwork.png',
+        'lastUpdateTime': 1700000000,
+        'categories': {'0': 'Comedy'},
+        'explicit': true,
+        'episodeCount': 10,
+      };
+
+      final unified = UnifiedPinepodsPodcast.fromJson(json);
+      expect(unified.toJson(), json);
+    });
+  });
+
+  group('PinepodsSearchResult', () {
+    test('getUnifiedPodcasts merges PodcastIndex feeds and iTunes results', () {
+      final result = PinepodsSearchResult(
+        feeds: [_pinepodsPodcast(id: 1, title: 'From Index')],
+        results: [_itunesPodcast(trackId: 2)],
+      );
+
+      final unified = result.getUnifiedPodcasts();
+
+      expect(unified, hasLength(2));
+      expect(unified[0].title, 'From Index');
+      expect(unified[0].indexId, 1);
+      expect(unified[1].id, 2);
+    });
+
+    test('getUnifiedPodcasts is empty when both feeds and results are null', () {
+      final result = PinepodsSearchResult();
+      expect(result.getUnifiedPodcasts(), isEmpty);
+    });
+
+    test('fromJson/toJson round-trips status, resultCount, feeds, and results', () {
+      final json = {
+        'status': 'true',
+        'resultCount': 1,
+        'feeds': [
+          {
+            'id': 1,
+            'title': 'T',
+            'url': 'https://example.com/feed.xml',
+            'originalUrl': 'https://example.com/original.xml',
+            'link': 'https://example.com',
+            'description': 'D',
+            'author': 'A',
+            'ownerName': 'O',
+            'image': 'https://example.com/art.png',
+            'artwork': 'https://example.com/artwork.png',
+            'lastUpdateTime': 0,
+            'categories': null,
+            'explicit': false,
+            'episodeCount': 0,
+          }
+        ],
+        'results': null,
+      };
+
+      final result = PinepodsSearchResult.fromJson(json);
+
+      expect(result.status, 'true');
+      expect(result.resultCount, 1);
+      expect(result.feeds, hasLength(1));
+      expect(result.results, isNull);
+    });
+  });
+
+  group('SearchProviderExtension', () {
+    test('has a display name and value for every provider', () {
+      expect(SearchProvider.podcastIndex.name, 'Podcast Index');
+      expect(SearchProvider.podcastIndex.value, 'podcast_index');
+      expect(SearchProvider.itunes.name, 'iTunes');
+      expect(SearchProvider.itunes.value, 'itunes');
+    });
+  });
+}

--- a/mobile/test/entities/podcast_test.dart
+++ b/mobile/test/entities/podcast_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/podcast.dart';
+
+void main() {
+  group('construction', () {
+    test('upgrades http feed/artwork URLs to https', () {
+      final podcast = Podcast(
+        guid: 'guid-1',
+        url: 'http://example.com/feed.xml',
+        link: 'https://example.com',
+        title: 'Some Podcast',
+        imageUrl: 'http://example.com/art.png',
+      );
+
+      expect(podcast.url, 'https://example.com/feed.xml');
+      expect(podcast.imageUrl, 'https://example.com/art.png');
+    });
+  });
+
+  group('subscribed', () {
+    test('is false before the podcast has a database id', () {
+      final podcast = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'T');
+      expect(podcast.subscribed, isFalse);
+    });
+
+    test('is true once a database id is assigned', () {
+      final podcast = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'T')..id = 5;
+      expect(podcast.subscribed, isTrue);
+    });
+  });
+
+  group('lastUpdated', () {
+    test('defaults to the epoch-adjacent 1970-01-01 when never set', () {
+      final podcast = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'T');
+      expect(podcast.lastUpdated, DateTime(1970, 1, 1));
+    });
+
+    test('returns whatever was set via the setter', () {
+      final podcast = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'T');
+      final when = DateTime(2024, 1, 1);
+
+      podcast.lastUpdated = when;
+
+      expect(podcast.lastUpdated, when);
+    });
+  });
+
+  group('toMap/fromMap', () {
+    test('round-trips guid, title, url, and filter/sort selections', () {
+      final original = Podcast(
+        guid: 'guid-1',
+        url: 'https://example.com/feed.xml',
+        link: 'https://example.com',
+        title: 'Some Podcast',
+        description: 'A podcast',
+        copyright: '2024',
+        filter: PodcastEpisodeFilter.notPlayed,
+        sort: PodcastEpisodeSort.alphabeticalDescending,
+        lastUpdated: DateTime(2024, 3, 1),
+      );
+
+      final restored = Podcast.fromMap(7, original.toMap());
+
+      expect(restored.id, 7);
+      expect(restored.guid, original.guid);
+      expect(restored.title, original.title);
+      expect(restored.url, original.url);
+      expect(restored.description, original.description);
+      expect(restored.copyright, original.copyright);
+      expect(restored.filter, PodcastEpisodeFilter.notPlayed);
+      expect(restored.sort, PodcastEpisodeSort.alphabeticalDescending);
+      expect(restored.lastUpdated, DateTime(2024, 3, 1));
+    });
+
+    test('every filter enum value round-trips through its stored id', () {
+      for (final filter in PodcastEpisodeFilter.values) {
+        final original = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'T', filter: filter);
+        final restored = Podcast.fromMap(1, original.toMap());
+
+        expect(restored.filter, filter, reason: 'failed for $filter');
+      }
+    });
+
+    test('every sort enum value round-trips through its stored id', () {
+      for (final sort in PodcastEpisodeSort.values) {
+        final original = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'T', sort: sort);
+        final restored = Podcast.fromMap(1, original.toMap());
+
+        expect(restored.sort, sort, reason: 'failed for $sort');
+      }
+    });
+  });
+
+  group('equality', () {
+    test('two podcasts with the same guid and url are equal', () {
+      final a = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'A');
+      final b = Podcast(guid: 'g', url: 'https://example.com/feed.xml', link: null, title: 'B');
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('podcasts with a different url are not equal', () {
+      final a = Podcast(guid: 'g', url: 'https://example.com/a.xml', link: null, title: 'T');
+      final b = Podcast(guid: 'g', url: 'https://example.com/b.xml', link: null, title: 'T');
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/test/entities/queue_test.dart
+++ b/mobile/test/entities/queue_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/queue.dart';
+
+void main() {
+  group('toMap/fromMap', () {
+    test('round-trips the list of guids', () {
+      final original = Queue(guids: ['guid-1', 'guid-2', 'guid-3']);
+
+      final restored = Queue.fromMap(1, original.toMap());
+
+      expect(restored.guids, original.guids);
+    });
+
+    test('an empty queue round-trips to an empty list', () {
+      final original = Queue(guids: []);
+
+      final restored = Queue.fromMap(1, original.toMap());
+
+      expect(restored.guids, isEmpty);
+    });
+
+    test('a missing "q" key defaults to an empty list rather than throwing', () {
+      final restored = Queue.fromMap(1, const {});
+      expect(restored.guids, isEmpty);
+    });
+  });
+}

--- a/mobile/test/entities/sleep_test.dart
+++ b/mobile/test/entities/sleep_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/sleep.dart';
+
+void main() {
+  group('equality', () {
+    test('two sleeps with the same type, duration, and episode count are equal', () {
+      final a = Sleep(type: SleepType.time, duration: const Duration(minutes: 30));
+      final b = Sleep(type: SleepType.time, duration: const Duration(minutes: 30));
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('sleeps with a different duration are not equal', () {
+      final a = Sleep(type: SleepType.time, duration: const Duration(minutes: 30));
+      final b = Sleep(type: SleepType.time, duration: const Duration(minutes: 45));
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('timeRemaining', () {
+    test('is approximately the configured duration right after creation', () {
+      final sleep = Sleep(type: SleepType.time, duration: const Duration(minutes: 10));
+
+      final remaining = sleep.timeRemaining;
+
+      expect(remaining.inSeconds, greaterThan(Duration(minutes: 10).inSeconds - 2));
+      expect(remaining.inSeconds, lessThanOrEqualTo(Duration(minutes: 10).inSeconds));
+    });
+
+    test('a zero-duration sleep has (approximately) no time remaining', () {
+      final sleep = Sleep(type: SleepType.none);
+
+      expect(sleep.timeRemaining.inSeconds, 0);
+    });
+  });
+}

--- a/mobile/test/entities/transcript_test.dart
+++ b/mobile/test/entities/transcript_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/transcript.dart';
+
+void main() {
+  group('TranscriptUrl', () {
+    test('upgrades an http url to https on construction', () {
+      final url = TranscriptUrl(url: 'http://example.com/t.json', type: TranscriptFormat.json);
+      expect(url.url, 'https://example.com/t.json');
+    });
+
+    test('every format round-trips through its stored numeric code', () {
+      for (final format in TranscriptFormat.values) {
+        final original = TranscriptUrl(url: 'https://example.com/t', type: format);
+        final restored = TranscriptUrl.fromMap(original.toMap());
+
+        expect(restored.type, format, reason: 'failed for $format');
+      }
+    });
+
+    test('round-trips url, language, and rel', () {
+      final original = TranscriptUrl(
+        url: 'https://example.com/t.srt',
+        type: TranscriptFormat.subrip,
+        language: 'en',
+        rel: 'captions',
+      );
+
+      final restored = TranscriptUrl.fromMap(original.toMap());
+
+      expect(restored.url, original.url);
+      expect(restored.language, 'en');
+      expect(restored.rel, 'captions');
+    });
+
+    test('equality is based on url, type, language, and rel', () {
+      final a = TranscriptUrl(url: 'https://example.com/t', type: TranscriptFormat.json, language: 'en');
+      final b = TranscriptUrl(url: 'https://example.com/t', type: TranscriptFormat.json, language: 'en');
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  group('Transcript', () {
+    test('transcriptAvailable is false with no subtitles and not filtered', () {
+      final transcript = Transcript();
+      expect(transcript.transcriptAvailable, isFalse);
+    });
+
+    test('transcriptAvailable is true once there are subtitles', () {
+      final transcript = Transcript(subtitles: [Subtitle(index: 0, start: Duration.zero)]);
+      expect(transcript.transcriptAvailable, isTrue);
+    });
+
+    test('transcriptAvailable is true when explicitly marked filtered, even with no subtitles', () {
+      final transcript = Transcript(filtered: true);
+      expect(transcript.transcriptAvailable, isTrue);
+    });
+
+    test('toMap/fromMap round-trips guid and subtitles', () {
+      final original = Transcript(
+        guid: 'guid-1',
+        subtitles: [
+          Subtitle(index: 0, start: Duration.zero, end: const Duration(seconds: 5), speaker: 'Alice', data: 'Hello'),
+        ],
+      );
+
+      final restored = Transcript.fromMap(3, original.toMap());
+
+      expect(restored.id, 3);
+      expect(restored.guid, 'guid-1');
+      expect(restored.subtitles, hasLength(1));
+      expect(restored.subtitles.first.speaker, 'Alice');
+      expect(restored.subtitles.first.data, 'Hello');
+    });
+  });
+
+  group('Subtitle', () {
+    test('round-trips index, start/end, speaker, and data', () {
+      final original = Subtitle(
+        index: 2,
+        start: const Duration(seconds: 10),
+        end: const Duration(seconds: 15),
+        speaker: 'Bob',
+        data: 'Some line',
+      );
+
+      final restored = Subtitle.fromMap(original.toMap());
+
+      expect(restored.index, 2);
+      expect(restored.start, const Duration(seconds: 10));
+      expect(restored.end, const Duration(seconds: 15));
+      expect(restored.speaker, 'Bob');
+      expect(restored.data, 'Some line');
+    });
+
+    test('equality is based on index, timing, speaker, and data', () {
+      final a = Subtitle(index: 0, start: Duration.zero, end: const Duration(seconds: 1));
+      final b = Subtitle(index: 0, start: Duration.zero, end: const Duration(seconds: 1));
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+}

--- a/mobile/test/entities/user_stats_test.dart
+++ b/mobile/test/entities/user_stats_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/user_stats.dart';
+
+UserStats _stats({
+  int timeListened = 0,
+  String userCreated = '2024-01-15T00:00:00.000Z',
+  String podSyncType = 'none',
+  String gpodderUrl = '',
+}) {
+  return UserStats(
+    userCreated: userCreated,
+    podcastsPlayed: 0,
+    timeListened: timeListened,
+    podcastsAdded: 0,
+    episodesSaved: 0,
+    episodesDownloaded: 0,
+    gpodderUrl: gpodderUrl,
+    podSyncType: podSyncType,
+  );
+}
+
+void main() {
+  group('fromJson/toJson', () {
+    test('round-trips every field', () {
+      final json = {
+        'UserCreated': '2024-01-15T00:00:00.000Z',
+        'PodcastsPlayed': 5,
+        'TimeListened': 120,
+        'PodcastsAdded': 3,
+        'EpisodesSaved': 7,
+        'EpisodesDownloaded': 2,
+        'GpodderUrl': 'http://localhost:8042',
+        'Pod_Sync_Type': 'gpodder',
+      };
+
+      final stats = UserStats.fromJson(json);
+
+      expect(stats.podcastsPlayed, 5);
+      expect(stats.timeListened, 120);
+      expect(stats.podcastsAdded, 3);
+      expect(stats.episodesSaved, 7);
+      expect(stats.episodesDownloaded, 2);
+      expect(stats.gpodderUrl, 'http://localhost:8042');
+      expect(stats.podSyncType, 'gpodder');
+      expect(stats.toJson(), json);
+    });
+
+    test('defaults missing fields to empty/zero rather than throwing', () {
+      final stats = UserStats.fromJson(const {});
+
+      expect(stats.userCreated, '');
+      expect(stats.podcastsPlayed, 0);
+      expect(stats.gpodderUrl, '');
+    });
+  });
+
+  group('formattedTimeListened', () {
+    test('is "0 minutes" when nothing has been listened to', () {
+      expect(_stats(timeListened: 0).formattedTimeListened, '0 minutes');
+    });
+
+    test('pluralizes a single minute correctly', () {
+      expect(_stats(timeListened: 1).formattedTimeListened, '1 minute');
+    });
+
+    test('shows minutes only under an hour', () {
+      expect(_stats(timeListened: 45).formattedTimeListened, '45 minutes');
+    });
+
+    test('shows only hours when there are no leftover minutes', () {
+      expect(_stats(timeListened: 120).formattedTimeListened, '2 hours');
+    });
+
+    test('shows a singular hour correctly', () {
+      expect(_stats(timeListened: 60).formattedTimeListened, '1 hour');
+    });
+
+    test('shows hours and minutes together', () {
+      expect(_stats(timeListened: 125).formattedTimeListened, '2 hours 5 minutes');
+    });
+  });
+
+  group('formattedUserCreated', () {
+    test('formats a valid ISO date as D/M/YYYY', () {
+      expect(_stats(userCreated: '2024-03-05T00:00:00.000Z').formattedUserCreated, '5/3/2024');
+    });
+
+    test('returns the raw string unchanged if it cannot be parsed', () {
+      expect(_stats(userCreated: 'not a date').formattedUserCreated, 'not a date');
+    });
+  });
+
+  group('syncStatusDescription', () {
+    test('describes "none" as Not Syncing', () {
+      expect(_stats(podSyncType: 'none').syncStatusDescription, 'Not Syncing');
+    });
+
+    test('describes the internal gpodder server distinctly from an external one', () {
+      expect(
+        _stats(podSyncType: 'gpodder', gpodderUrl: 'http://localhost:8042').syncStatusDescription,
+        'Internal gpodder',
+      );
+      expect(
+        _stats(podSyncType: 'gpodder', gpodderUrl: 'https://gpodder.example.com').syncStatusDescription,
+        'External gpodder',
+      );
+    });
+
+    test('describes nextcloud sync', () {
+      expect(_stats(podSyncType: 'nextcloud').syncStatusDescription, 'Nextcloud');
+    });
+
+    test('is case-insensitive when matching the sync type', () {
+      expect(_stats(podSyncType: 'NONE').syncStatusDescription, 'Not Syncing');
+    });
+
+    test('falls back to Unknown for an unrecognized sync type', () {
+      expect(_stats(podSyncType: 'something-else').syncStatusDescription, 'Unknown sync type');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The mobile app has ~166 `lib/` source files and, before this, only 4 test files (each covering pure logic extracted for a specific bug fix elsewhere), for an app-wide line coverage estimate of roughly 0.35%. This adds unit tests for the app's pure, dependency-free logic layer - the parts that don't need file-system/platform-channel/network mocking - to build a regression safety net for **existing** behavior. No production code is changed; this is test-only.

- **`core/`**: `date_utils` (pubdate parsing/relative labels, including the naive-string-as-UTC reinterpretation the backend's date format requires), `extensions` (`chunk`, `forceHttps` incl. the local-network exceptions, `toTenth`), and the pure string-sanitizing helpers in `utils` (`safePath`/`safeFile` - the rest of that file is platform/IO-dependent and out of scope here).
- **`entities/`**: `fromJson`/`toJson` or `toMap`/`fromMap` round-trips and computed getters for `Episode`, `PinepodsEpisode`, `Downloadable`, `AppSettings`, `Podcast`, `Chapter`, `Person`, `Funding`, `PendingAction`, `Queue`, `Sleep`, `Transcript`/`TranscriptUrl`/`Subtitle`, `UserStats`, `Persistable`, the home-overview models (`HomePodcast`/`HomeEpisode`/`WeeklyStats`/`HomeOverview`/`Playlist`), and the search-provider unification logic in `PinepodsSearchResult`/`UnifiedPinepodsPodcast`.

**Deliberately out of scope** (left for future, separately-scoped work): widgets/screens, blocs, `repository/sembast` persistence, and any service that talks to the network, filesystem, or platform channels - all of which need substantially more test scaffolding than a plain unit test. `entities/feed.dart` and `entities/search_providers.dart` were skipped as plain data holders with no logic to verify.

App-wide line coverage estimate goes from ~0.35% to ~2.4% (1026/42449 non-blank/comment lines), concentrated in the business-logic layer rather than spread thin across the UI.

## Test plan
- [x] `flutter test` - 215/215 tests pass (195 new + the 4 pre-existing files)
- [x] `flutter analyze test/core test/entities` - no issues
- [x] Diff is entirely additive and confined to `mobile/test/` - no production code touched
