### PR TITLE
Apply full filter set to MySQL playlist count query

### DIFF
--- a/rust-api/src/database.rs
+++ b/rust-api/src/database.rs
@@ -28357,20 +28357,76 @@ impl DatabasePool {
                     ));
                 }
                 
-                // Continue with all other MySQL filters...
+                // Podcast filter - handle JSON array of podcast IDs (MySQL/MariaDB).
+                // MariaDB reports the JSON column as a binary BLOB charset, so decode as
+                // raw bytes first and only fall back to a direct String decode (see #773).
+                let podcast_ids_json_owned: Option<String> = match playlist.try_get::<Option<Vec<u8>>, _>("PodcastIDs") {
+                    Ok(bytes_opt) => bytes_opt.map(|bytes| String::from_utf8_lossy(&bytes).into_owned()),
+                    Err(_) => playlist.try_get::<Option<String>, _>("PodcastIDs")?,
+                };
+                if let Some(podcast_ids_json) = podcast_ids_json_owned.as_ref() {
+                    if !podcast_ids_json.is_empty() && podcast_ids_json != "[]" && podcast_ids_json != "null" {
+                        match serde_json::from_str::<Vec<i32>>(podcast_ids_json) {
+                            Ok(podcast_ids) if !podcast_ids.is_empty() && !podcast_ids.contains(&-1) => {
+                                let podcast_ids_str = podcast_ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(",");
+                                where_conditions.push(format!("p.PodcastID IN ({})", podcast_ids_str));
+                            }
+                            Ok(_) => {}
+                            Err(e) => warn!("⚠️ Failed to parse MySQL podcast IDs JSON '{}': {}", podcast_ids_json, e),
+                        }
+                    }
+                }
+
+                // Play state filters - must mirror get_playlist_episodes_dynamic exactly
+                // so the cached count matches what the detail view returns
+                let mut play_state_conditions = Vec::new();
+                if playlist.try_get::<bool, _>("IncludeUnplayed")? {
+                    play_state_conditions.push("(e.completed IS NOT TRUE AND (h.ListenDuration IS NULL OR h.ListenDuration = 0))".to_string());
+                }
+                if playlist.try_get::<bool, _>("IncludePartiallyPlayed")? {
+                    play_state_conditions.push(
+                        "(h.ListenDuration > 0 AND h.ListenDuration < e.EpisodeDuration * 0.9 AND (e.EpisodeDuration - h.ListenDuration) > 30)".to_string()
+                    );
+                }
+                if playlist.try_get::<bool, _>("IncludePlayed")? {
+                    play_state_conditions.push(
+                        "(e.completed IS TRUE OR (h.ListenDuration IS NOT NULL AND (h.ListenDuration >= e.EpisodeDuration * 0.9 OR (e.EpisodeDuration - h.ListenDuration) <= 30)))".to_string()
+                    );
+                }
+
+                if !play_state_conditions.is_empty() {
+                    where_conditions.push(format!("({})", play_state_conditions.join(" OR ")));
+                } else {
+                    where_conditions.push("FALSE".to_string());
+                }
+
+                // Progress percentage filters
+                if let Some(min_progress) = playlist.try_get::<Option<f64>, _>("PlayProgressMin")? {
+                    where_conditions.push(format!(
+                        "(COALESCE(h.ListenDuration, 0) / NULLIF(e.EpisodeDuration, 0)) >= {}",
+                        min_progress / 100.0
+                    ));
+                }
+                if let Some(max_progress) = playlist.try_get::<Option<f64>, _>("PlayProgressMax")? {
+                    where_conditions.push(format!(
+                        "(COALESCE(h.ListenDuration, 0) / NULLIF(e.EpisodeDuration, 0)) <= {}",
+                        max_progress / 100.0
+                    ));
+                }
+
                 let where_clause = if where_conditions.is_empty() {
                     String::new()
                 } else {
                     format!(" WHERE {}", where_conditions.join(" AND "))
                 };
-                
+
                 let final_query = format!("{}{}", query_parts.join(" "), where_clause);
-                
+
                 let count: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(final_query.as_str()))
                     .bind(user_id)
                     .fetch_one(pool)
                     .await?;
-                
+
                 let final_count = if let Some(max_eps) = playlist.try_get::<Option<i32>, _>("MaxEpisodes")? {
                     if max_eps > 0 {
                         std::cmp::min(count as i32, max_eps)


### PR DESCRIPTION
# Complete the MySQL/MariaDB playlist count filters

## What this fixes

On MySQL/MariaDB, the cached playlist episode count (the badge shown on the playlists list) can be too high. It counts episodes that the playlist's filters should exclude, including completed episodes when "Include Played" is off. The count and the actual episode list disagree.

The cause is in `count_playlist_episodes_dynamic` in `rust-api/src/database.rs`. Its Postgres branch applies the full filter set, but the MySQL branch was left unfinished: after the duration and time filters there was a `// Continue with all other MySQL filters...` stub and nothing else, so the podcast filter, the play-state filter (unplayed / partially played / played), and the progress-percentage filter were never applied. The count query therefore matched far more episodes than the detail view returns.

This is the count-only sibling of the display logic. The detail view (`get_playlist_episodes_dynamic`) already applies all of these filters correctly in both dialects, so the list was right and only the badge was wrong.

I found this while investigating #716 (playlists showing completed episodes). That display bug was already fixed on main by #811 and shipped in 0.9.0; this count discrepancy is a separate, MySQL-only leftover.

## The change

I filled in the MySQL branch so it mirrors the Postgres branch of the same function, using the exact MySQL clauses already used by `get_playlist_episodes_dynamic`'s MySQL branch. Keeping them identical is deliberate: the cached count is now computed from the same predicates the detail view uses, so the badge and the list agree.

Three filters were added where the stub was:

1. Podcast filter. Postgres reads `podcastids` as a native integer array; MySQL/MariaDB stores it as a JSON string that the driver reports as a binary BLOB, so it is decoded as raw bytes first with a String fallback, the same pattern introduced for #773 and already used by the display query. Then `p.PodcastID IN (...)`, skipping the `-1` "all podcasts" sentinel.
2. Play-state filter (unplayed / partially played / played), OR-combined, with `FALSE` when none is selected.
3. Progress-percentage filter (min/max).

## Filter-by-filter equivalence

Postgres branch of `count_playlist_episodes_dynamic` (the source of truth) vs. the completed MySQL branch. Differences are dialect-only.

**Podcast filter**

- Postgres: `podcastids` is `Option<Vec<i32>>` (native array); if non-empty and not `[-1]` → `p.podcastid IN (ids)`.
- MySQL (added): `PodcastIDs` is a JSON string decoded BLOB-safe (bytes → String → `serde_json` to `Vec<i32>`); if non-empty and not `[-1]` → `p.PodcastID IN (ids)`.
- Equivalent. The only difference is how the column is read, which is a genuine schema difference between the two backends and follows the file's existing #773 convention. Same IN-list semantics, same `-1` sentinel handling.

**Play state: unplayed**

- Postgres: `(e.completed IS NOT TRUE AND (h.listenduration IS NULL OR h.listenduration = 0))`
- MySQL: `(e.completed IS NOT TRUE AND (h.ListenDuration IS NULL OR h.ListenDuration = 0))`
- Identical apart from column casing (MySQL column names are case-insensitive; casing copied verbatim from the display query).

**Play state: partially played**

- Postgres: `(h.listenduration > 0 AND h.listenduration < e.episodeduration * 0.9 AND (e.episodeduration - h.listenduration) > 30)`
- MySQL: `(h.ListenDuration > 0 AND h.ListenDuration < e.EpisodeDuration * 0.9 AND (e.EpisodeDuration - h.ListenDuration) > 30)`
- Identical apart from casing. Same 90% threshold and 30-second end margin.

**Play state: played**

- Postgres: `(e.completed IS TRUE OR (h.listenduration IS NOT NULL AND (h.listenduration >= e.episodeduration * 0.9 OR (e.episodeduration - h.listenduration) <= 30)))`
- MySQL: `(e.completed IS TRUE OR (h.ListenDuration IS NOT NULL AND (h.ListenDuration >= e.EpisodeDuration * 0.9 OR (e.EpisodeDuration - h.ListenDuration) <= 30)))`
- Identical apart from casing.

**Play-state combination**

- Both: OR-join the selected conditions; if none selected, push `FALSE` (so nothing matches). Identical.

**Progress percentage**

- Postgres: `(COALESCE(h.listenduration, 0)::float / NULLIF(e.episodeduration, 0)) >= min` and `<= max`.
- MySQL: `(COALESCE(h.ListenDuration, 0) / NULLIF(e.EpisodeDuration, 0)) >= min` and `<= max`.
- Equivalent. The `::float` cast is Postgres-only syntax; MySQL division is already floating-point, so it is dropped, exactly as the MySQL display query does it. Same `/100.0` scaling of the stored percentage.

Every clause now added to the MySQL count branch is a character-for-character copy (modulo the dropped `::float` cast) of the corresponding clause in the MySQL branch of `get_playlist_episodes_dynamic`, which is the query the detail view runs. That is what guarantees the count and the list agree.

The duration and time filters were already present and correct in the MySQL count branch and are unchanged. The trailing `MaxEpisodes` cap is unchanged.

## Verification

Verified on MariaDB 10.11.14. Seeded two podcasts and eight episodes (unplayed, partial, and three flavours of completed: the completed flag, listened past 90%, and within 30 seconds of the end), with a playlist over podcast 1 and "Include Played" off. The old truncated count returned 8; the fixed count returns 3; the detail-view query (`get_playlist_episodes_dynamic`) returns those same 3 episodes. The over-count of 5 is exactly the two filters the old branch was missing: the 3 completed episodes it should have excluded, plus podcast 2's 2 episodes it should not have counted at all. Five config variations all held (Include Played on returns 6==6, played-only returns 3, a progress-minimum filter returns 2, dropping the podcast filter returns 5, and the old query stays 8 regardless of the toggle).

This was a SQL-level check: the schema and both WHERE clauses were reconstructed from the code and the MySQL migration definitions, not exercised through a running backend. The `PodcastIDs` BLOB decode from #773 is applied at the Rust driver layer and was reproduced by hand.

Postgres behavior is unchanged (that branch was untouched).
