### PR TITLE
Mobile: PR-gating test CI + business-logic test layer

### DIFF
--- a/.github/workflows/mobile-tests.yml
+++ b/.github/workflows/mobile-tests.yml
@@ -1,0 +1,53 @@
+name: Mobile Tests
+
+permissions:
+  contents: read
+
+# Runs the Flutter mobile app's analyzer and unit tests. Scoped with a path
+# filter so it only fires when the mobile app (or this workflow) changes -
+# unrelated backend/web/docs PRs don't pay for a Flutter toolchain spin-up.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "mobile/**"
+      - ".github/workflows/mobile-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "mobile/**"
+      - ".github/workflows/mobile-tests.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Analyze & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.44.1"
+          channel: "stable"
+          cache: true
+
+      # Also runs l10n codegen (pubspec has generate: true + l10n.yaml), so this
+      # must precede analyze/test.
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Blocks only on real analyzer *errors* (compile-level breakage). The app
+      # currently carries ~500 pre-existing style infos/warnings; failing the
+      # gate on those would make it useless noise. Tighten to fatal warnings once
+      # that backlog is cleared.
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Test
+        run: flutter test

--- a/mobile/lib/repository/sembast/sembast_database_service.dart
+++ b/mobile/lib/repository/sembast/sembast_database_service.dart
@@ -19,10 +19,17 @@ class DatabaseService {
   int? version = 1;
   DatabaseUpgrade? upgraderCallback;
 
+  /// Injectable database factory. When null the default disk-backed
+  /// [databaseFactoryIo] is used (with a path resolved via path_provider);
+  /// tests pass an in-memory factory (`newDatabaseFactoryMemory()`) to avoid
+  /// disk and platform-channel access.
+  final DatabaseFactory? databaseFactory;
+
   DatabaseService(
     this.databaseName, {
     this.version,
     this.upgraderCallback,
+    this.databaseFactory,
   });
 
   Future<Database> get database async {
@@ -35,17 +42,29 @@ class DatabaseService {
   }
 
   Future _openDatabase() async {
-    final appDocumentDir = await getApplicationDocumentsDirectory();
-    final dbPath = join(appDocumentDir.path, databaseName);
-    final database = await databaseFactoryIo.openDatabase(
-      dbPath,
-      version: version,
-      onVersionChanged: (db, oldVersion, newVersion) async {
-        if (upgraderCallback != null) {
-          await upgraderCallback!(db, oldVersion, newVersion);
-        }
-      },
-    );
+    Future<void> onVersionChanged(Database db, int oldVersion, int newVersion) async {
+      if (upgraderCallback != null) {
+        await upgraderCallback!(db, oldVersion, newVersion);
+      }
+    }
+
+    final Database database;
+    if (databaseFactory != null) {
+      // In-memory factories key on the name rather than a filesystem path.
+      database = await databaseFactory!.openDatabase(
+        databaseName,
+        version: version,
+        onVersionChanged: onVersionChanged,
+      );
+    } else {
+      final appDocumentDir = await getApplicationDocumentsDirectory();
+      final dbPath = join(appDocumentDir.path, databaseName);
+      database = await databaseFactoryIo.openDatabase(
+        dbPath,
+        version: version,
+        onVersionChanged: onVersionChanged,
+      );
+    }
 
     _databaseCompleter!.complete(database);
   }

--- a/mobile/lib/repository/sembast/sembast_repository.dart
+++ b/mobile/lib/repository/sembast/sembast_repository.dart
@@ -41,8 +41,10 @@ class SembastRepository extends Repository {
   SembastRepository({
     bool cleanup = true,
     String databaseName = 'pinepods.db',
+    DatabaseFactory? databaseFactory,
   }) {
-    _databaseService = DatabaseService(databaseName, version: 2, upgraderCallback: dbUpgrader);
+    _databaseService = DatabaseService(databaseName,
+        version: 2, upgraderCallback: dbUpgrader, databaseFactory: databaseFactory);
 
     if (cleanup) {
       _cleanupEpisodes().then((value) {

--- a/mobile/lib/services/pinepods/login_service.dart
+++ b/mobile/lib/services/pinepods/login_service.dart
@@ -35,12 +35,18 @@ class PinepodsLoginService {
   /// Check whether [serverUrl] is a reachable PinePods instance, surfacing the
   /// specific failure reason (TLS/certificate, DNS/connection, timeout, or a
   /// reachable-but-not-PinePods host).
-  static Future<ServerCheckResult> checkServer(String serverUrl) async {
+  ///
+  /// [client] is injectable so this can be unit-tested against canned responses
+  /// and failures without touching the network; when omitted a short-lived
+  /// [http.Client] is created and closed for the single request.
+  static Future<ServerCheckResult> checkServer(String serverUrl,
+      {http.Client? client}) async {
     final normalizedUrl = serverUrl.trim().replaceAll(RegExp(r'/$'), '');
     final url = Uri.parse('$normalizedUrl/api/pinepods_check');
+    final httpClient = client ?? http.Client();
 
     try {
-      final response = await http
+      final response = await httpClient
           .get(url, headers: {'User-Agent': userAgent})
           .timeout(_requestTimeout);
 
@@ -76,6 +82,8 @@ class PinepodsLoginService {
           "That doesn't look like a valid server address.");
     } catch (e) {
       return ServerCheckResult.error('Could not connect: $e');
+    } finally {
+      if (client == null) httpClient.close();
     }
   }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -701,6 +701,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.7.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   mp3_info:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -62,6 +62,9 @@ dependencies:
 
 dev_dependencies:
   mockito: ^5.7.0
+  # mocktail needs no codegen/build_runner - preferred for new tests. mockito is
+  # kept for the existing hand-written-mock tests until they're migrated.
+  mocktail: ^1.0.4
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/mobile/test/bloc/episode_bloc_test.dart
+++ b/mobile/test/bloc/episode_bloc_test.dart
@@ -1,0 +1,127 @@
+// Tests the rxdart-based EpisodeBloc by injecting mocked services, pushing its
+// input sinks, and asserting on the emitted BlocState stream. This is the
+// reusable pattern for the app's hand-rolled (non-flutter_bloc) blocs: no
+// bloc_test, just expectLater(stream, emitsInOrder([...])) and mock verification.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pinepods_mobile/bloc/podcast/episode_bloc.dart';
+import 'package:pinepods_mobile/entities/episode.dart';
+import 'package:pinepods_mobile/state/bloc_state.dart';
+import 'package:pinepods_mobile/state/episode_state.dart';
+
+import '../support/factories.dart';
+import '../support/fakes.dart';
+
+void main() {
+  late MockPodcastService podcastService;
+  late MockAudioPlayerService audioPlayerService;
+  late EpisodeBloc bloc;
+
+  setUpAll(registerCommonFallbacks);
+
+  setUp(() {
+    podcastService = MockPodcastService();
+    audioPlayerService = MockAudioPlayerService();
+    // The bloc subscribes to this at construction; an empty stream means no
+    // external episode events fire during the test.
+    when(() => podcastService.episodeListener)
+        .thenAnswer((_) => Stream<EpisodeState>.empty());
+    bloc = EpisodeBloc(
+      podcastService: podcastService,
+      audioPlayerService: audioPlayerService,
+    );
+  });
+
+  tearDown(() => bloc.dispose());
+
+  test('fetchEpisodes emits Loading then Populated with the loaded episodes', () async {
+    final loaded = [buildEpisode(guid: 'e1'), buildEpisode(guid: 'e2')];
+    when(() => podcastService.loadEpisodes()).thenAnswer((_) async => loaded);
+
+    expectLater(
+      bloc.episodes,
+      emitsInOrder([
+        isA<BlocLoadingState<List<Episode>>>(),
+        isA<BlocPopulatedState<List<Episode>>>()
+            .having((s) => s.results, 'results', hasLength(2)),
+      ]),
+    );
+
+    bloc.fetchEpisodes(false);
+  });
+
+  test('a silent fetch skips the Loading state and emits only Populated', () async {
+    when(() => podcastService.loadEpisodes()).thenAnswer((_) async => <Episode>[]);
+
+    expectLater(
+      bloc.episodes,
+      emitsInOrder([
+        isA<BlocPopulatedState<List<Episode>>>(),
+      ]),
+    );
+
+    bloc.fetchEpisodes(true);
+  });
+
+  test('fetchDownloads emits Loading then Populated from loadDownloads', () async {
+    when(() => podcastService.loadDownloads())
+        .thenAnswer((_) async => [buildEpisode(guid: 'd1')]);
+
+    expectLater(
+      bloc.downloads,
+      emitsInOrder([
+        isA<BlocLoadingState<List<Episode>>>(),
+        isA<BlocPopulatedState<List<Episode>>>()
+            .having((s) => s.results, 'results', hasLength(1)),
+      ]),
+    );
+
+    bloc.fetchDownloads(false);
+  });
+
+  test('togglePlayed delegates to the service and refreshes downloads', () async {
+    final episode = buildEpisode(guid: 'e1');
+    when(() => podcastService.toggleEpisodePlayed(any())).thenAnswer((_) async {});
+    when(() => podcastService.loadDownloads()).thenAnswer((_) async => <Episode>[]);
+
+    // The post-toggle refresh only runs when the downloads output is observed.
+    final sub = bloc.downloads!.listen((_) {});
+    addTearDown(sub.cancel);
+
+    bloc.togglePlayed(episode);
+    await pumpEventQueue();
+
+    verify(() => podcastService.toggleEpisodePlayed(episode)).called(1);
+    // Marking played refreshes the downloads list.
+    verify(() => podcastService.loadDownloads()).called(1);
+  });
+
+  test('deleteDownload stops playback only when deleting the now-playing episode', () async {
+    final playing = buildEpisode(guid: 'now-playing');
+    when(() => audioPlayerService.nowPlaying).thenReturn(playing);
+    when(() => audioPlayerService.stop()).thenAnswer((_) async {});
+    when(() => podcastService.deleteDownload(any())).thenAnswer((_) async {});
+    when(() => podcastService.loadDownloads()).thenAnswer((_) async => <Episode>[]);
+
+    bloc.deleteDownload(playing);
+    await pumpEventQueue();
+
+    verify(() => audioPlayerService.stop()).called(1);
+    verify(() => podcastService.deleteDownload(playing)).called(1);
+  });
+
+  test('deleteDownload does not stop playback for a different episode', () async {
+    final other = buildEpisode(guid: 'other');
+    when(() => audioPlayerService.nowPlaying).thenReturn(buildEpisode(guid: 'now-playing'));
+    when(() => audioPlayerService.stop()).thenAnswer((_) async {});
+    when(() => podcastService.deleteDownload(any())).thenAnswer((_) async {});
+    when(() => podcastService.loadDownloads()).thenAnswer((_) async => <Episode>[]);
+
+    bloc.deleteDownload(other);
+    await pumpEventQueue();
+
+    verifyNever(() => audioPlayerService.stop());
+    verify(() => podcastService.deleteDownload(other)).called(1);
+  });
+}

--- a/mobile/test/bloc/queue_bloc_test.dart
+++ b/mobile/test/bloc/queue_bloc_test.dart
@@ -1,0 +1,81 @@
+// Tests QueueBloc's event routing: queue events pushed into its sink should
+// drive the matching AudioPlayerService calls, and its `queue` output should
+// forward the service's queueState stream.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pinepods_mobile/bloc/podcast/queue_bloc.dart';
+import 'package:pinepods_mobile/state/queue_event_state.dart';
+
+import '../support/factories.dart';
+import '../support/fakes.dart';
+
+void main() {
+  late MockPodcastService podcastService;
+  late MockAudioPlayerService audioPlayerService;
+  late StreamController<QueueListState> queueStateController;
+  late QueueBloc bloc;
+
+  setUpAll(registerCommonFallbacks);
+
+  setUp(() {
+    podcastService = MockPodcastService();
+    audioPlayerService = MockAudioPlayerService();
+    queueStateController = StreamController<QueueListState>.broadcast();
+    // QueueBloc subscribes to queueState at construction and, after a debounce,
+    // persists it via saveQueue (flushed when the stream closes in tearDown).
+    when(() => audioPlayerService.queueState).thenAnswer((_) => queueStateController.stream);
+    when(() => podcastService.saveQueue(any())).thenAnswer((_) async {});
+    bloc = QueueBloc(
+      audioPlayerService: audioPlayerService,
+      podcastService: podcastService,
+    );
+  });
+
+  tearDown(() async {
+    bloc.dispose();
+    await queueStateController.close();
+  });
+
+  test('a QueueAddEvent adds the episode to Up Next', () async {
+    final episode = buildEpisode(guid: 'e1');
+    when(() => audioPlayerService.addUpNextEpisode(any())).thenAnswer((_) async {});
+
+    bloc.queueEvent(QueueAddEvent(episode: episode));
+    await pumpEventQueue();
+
+    verify(() => audioPlayerService.addUpNextEpisode(episode)).called(1);
+  });
+
+  test('a QueueRemoveEvent removes the episode from Up Next', () async {
+    final episode = buildEpisode(guid: 'e1');
+    when(() => audioPlayerService.removeUpNextEpisode(any())).thenAnswer((_) async => true);
+
+    bloc.queueEvent(QueueRemoveEvent(episode: episode));
+    await pumpEventQueue();
+
+    verify(() => audioPlayerService.removeUpNextEpisode(episode)).called(1);
+  });
+
+  test('a QueueClearEvent clears Up Next', () async {
+    when(() => audioPlayerService.clearUpNext()).thenAnswer((_) async {});
+
+    bloc.queueEvent(QueueClearEvent());
+    await pumpEventQueue();
+
+    verify(() => audioPlayerService.clearUpNext()).called(1);
+  });
+
+  test('the queue output forwards the service queueState stream', () async {
+    final state = QueueListState(
+      playing: buildEpisode(guid: 'playing'),
+      queue: [buildEpisode(guid: 'q1')],
+    );
+
+    expectLater(bloc.queue, emits(state));
+
+    queueStateController.add(state);
+  });
+}

--- a/mobile/test/login_service_error_test.dart
+++ b/mobile/test/login_service_error_test.dart
@@ -1,18 +1,67 @@
+// Verifies checkServer maps transport failures to specific, non-generic user
+// messages. Previously these drove a real network request at
+// `does-not-exist.invalid`, which is slow and depends on the runner's DNS
+// behavior; now the failure is injected via a fake http.Client so the mapping
+// is exercised deterministically and offline.
+
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:pinepods_mobile/services/pinepods/login_service.dart';
 
 void main() {
-  test('checkServer maps an unreachable host to a connection/DNS message, not the generic one', () async {
-    final r = await PinepodsLoginService.checkServer('https://does-not-exist.invalid');
+  test('maps a DNS/connection failure to a reachability message, not the generic one', () async {
+    final client = MockClient(
+      (_) => throw const SocketException('Failed host lookup: does-not-exist.invalid'),
+    );
+
+    final r = await PinepodsLoginService.checkServer(
+      'https://does-not-exist.invalid',
+      client: client,
+    );
+
     expect(r.isPinepods, isFalse);
     expect(r.errorMessage, isNotNull);
     // Must NOT be the old misleading generic message.
     expect(r.errorMessage, isNot(equals('Not a valid PinePods server')));
-    expect(r.errorMessage!.toLowerCase(), anyOf(contains('reach'), contains('dns'), contains('connection')));
+    expect(
+      r.errorMessage!.toLowerCase(),
+      anyOf(contains('reach'), contains('dns'), contains('connection')),
+    );
   });
 
-  test('checkServer maps a malformed address to a helpful message', () async {
+  test('maps a reachable-but-not-PinePods host to a distinct message', () async {
+    final client = MockClient((_) async => http.Response('{"something_else": true}', 200));
+
+    final r = await PinepodsLoginService.checkServer(
+      'https://example.com',
+      client: client,
+    );
+
+    expect(r.isPinepods, isFalse);
+    expect(r.errorMessage, isNotNull);
+    expect(r.errorMessage!.toLowerCase(), contains('does not look like a pinepods'));
+  });
+
+  test('a genuine PinePods response checks out', () async {
+    final client = MockClient((_) async => http.Response('{"pinepods_instance": true}', 200));
+
+    final r = await PinepodsLoginService.checkServer(
+      'https://pods.example.com',
+      client: client,
+    );
+
+    expect(r.isPinepods, isTrue);
+    expect(r.errorMessage, isNull);
+  });
+
+  test('a malformed address is handled gracefully without throwing', () async {
+    // No injected client on purpose: a schemeless URL makes the real client
+    // throw synchronously before any I/O, exercising the catch-all mapping.
     final r = await PinepodsLoginService.checkServer('not-a-url');
+
     expect(r.isPinepods, isFalse);
     expect(r.errorMessage, isNotNull);
   });

--- a/mobile/test/repository/sembast_repository_test.dart
+++ b/mobile/test/repository/sembast_repository_test.dart
@@ -1,0 +1,168 @@
+// Exercises the real SembastRepository persistence contracts against an
+// in-memory sembast database (no disk, no platform channels). This is the layer
+// most of the app's data flows through and was previously untested.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/downloadable.dart';
+import 'package:pinepods_mobile/entities/pending_action.dart';
+import 'package:pinepods_mobile/repository/sembast/sembast_repository.dart';
+
+import '../support/factories.dart';
+import '../support/in_memory_repository.dart';
+
+void main() {
+  late SembastRepository repo;
+
+  setUp(() {
+    repo = newInMemoryRepository();
+  });
+
+  tearDown(() async {
+    await repo.close();
+  });
+
+  group('podcasts', () {
+    test('savePodcast assigns an id and a subscribed date, and is findable by guid', () async {
+      final saved = await repo.savePodcast(buildPodcast(guid: 'p1', title: 'My Show'));
+
+      expect(saved.id, isNotNull);
+      expect(saved.subscribedDate, isNotNull);
+
+      final found = await repo.findPodcastByGuid('p1');
+      expect(found, isNotNull);
+      expect(found!.id, saved.id);
+      expect(found.title, 'My Show');
+    });
+
+    test('findPodcastById returns the stored podcast', () async {
+      final saved = await repo.savePodcast(buildPodcast(guid: 'p1'));
+      final found = await repo.findPodcastById(saved.id!);
+      expect(found, isNotNull);
+      expect(found!.guid, 'p1');
+    });
+
+    test('re-saving the same guid updates in place rather than duplicating', () async {
+      await repo.savePodcast(buildPodcast(guid: 'p1', title: 'Original'));
+      // Same guid, no id -> savePodcast matches on guid and updates.
+      await repo.savePodcast(buildPodcast(guid: 'p1', title: 'Renamed'));
+
+      final subs = await repo.subscriptions();
+      expect(subs, hasLength(1));
+      expect(subs.single.title, 'Renamed');
+    });
+
+    test('subscriptions lists saved podcasts sorted case-insensitively by title', () async {
+      await repo.savePodcast(buildPodcast(guid: 'b', title: 'banana'));
+      await repo.savePodcast(buildPodcast(guid: 'a', title: 'Apple'));
+
+      final subs = await repo.subscriptions();
+      expect(subs.map((p) => p.title), ['Apple', 'banana']);
+    });
+
+    test('deletePodcast removes it from subscriptions', () async {
+      final saved = await repo.savePodcast(buildPodcast(guid: 'p1'));
+      await repo.deletePodcast(saved);
+
+      expect(await repo.subscriptions(), isEmpty);
+      expect(await repo.findPodcastByGuid('p1'), isNull);
+    });
+  });
+
+  group('episodes', () {
+    test('saveEpisode round-trips and is findable by guid and id', () async {
+      final saved = await repo.saveEpisode(buildEpisode(guid: 'e1', title: 'Ep 1'));
+
+      expect(saved.id, isNotNull);
+
+      final byGuid = await repo.findEpisodeByGuid('e1');
+      expect(byGuid, isNotNull);
+      expect(byGuid!.title, 'Ep 1');
+
+      final byId = await repo.findEpisodeById(saved.id!);
+      expect(byId!.guid, 'e1');
+    });
+
+    test('findDownloads returns only fully-downloaded (100%) episodes', () async {
+      await repo.saveEpisode(buildEpisode(
+        guid: 'e1',
+        downloadState: DownloadState.downloaded,
+        downloadPercentage: 100,
+      ));
+      await repo.saveEpisode(buildEpisode(guid: 'e2', downloadPercentage: 0));
+
+      final downloads = await repo.findDownloads();
+      expect(downloads.map((e) => e.guid), ['e1']);
+    });
+
+    test('deleteEpisode removes it', () async {
+      final saved = await repo.saveEpisode(buildEpisode(guid: 'e1'));
+      await repo.deleteEpisode(saved);
+      expect(await repo.findEpisodeByGuid('e1'), isNull);
+    });
+  });
+
+  group('queue', () {
+    test('saveQueue then loadQueue round-trips the queued episodes', () async {
+      // Persist the episodes first, then queue them. (saveQueue only persists
+      // ad-hoc/empty-pguid episodes, and does so without awaiting - so saving
+      // explicitly keeps this test about the queue round-trip, not that race.)
+      final a = await repo.saveEpisode(buildEpisode(guid: 'q1'));
+      final b = await repo.saveEpisode(buildEpisode(guid: 'q2'));
+
+      await repo.saveQueue([a, b]);
+
+      final loaded = await repo.loadQueue();
+      expect(loaded.map((e) => e.guid), containsAll(['q1', 'q2']));
+    });
+
+    test('loadQueue is empty when nothing has been queued', () async {
+      expect(await repo.loadQueue(), isEmpty);
+    });
+  });
+
+  group('pending actions (offline queue)', () {
+    test('savePendingAction assigns an id', () async {
+      final saved = await repo.savePendingAction(
+        PendingAction(type: PendingActionType.markCompleted, episodeId: 1, userId: 1),
+      );
+      expect(saved.id, isNotNull);
+    });
+
+    test('getPendingActions returns them oldest-first', () async {
+      await repo.savePendingAction(PendingAction(
+        type: PendingActionType.saveEpisode,
+        episodeId: 1,
+        userId: 1,
+        createdAt: DateTime(2024, 1, 1),
+      ));
+      await repo.savePendingAction(PendingAction(
+        type: PendingActionType.queue,
+        episodeId: 2,
+        userId: 1,
+        createdAt: DateTime(2024, 1, 2),
+      ));
+
+      final actions = await repo.getPendingActions();
+      expect(actions.map((a) => a.episodeId), [1, 2]);
+    });
+
+    test('deletePendingAction removes the given action', () async {
+      final saved = await repo.savePendingAction(
+        PendingAction(type: PendingActionType.markCompleted, episodeId: 9, userId: 1),
+      );
+
+      await repo.deletePendingAction(saved.id!);
+
+      expect(await repo.getPendingActions(), isEmpty);
+    });
+  });
+
+  test('separate in-memory repositories do not share data', () async {
+    await repo.savePodcast(buildPodcast(guid: 'p1'));
+
+    final other = newInMemoryRepository();
+    addTearDown(other.close);
+
+    expect(await other.subscriptions(), isEmpty);
+  });
+}

--- a/mobile/test/services/pinepods/pinepods_audio_service_parallel_test.dart
+++ b/mobile/test/services/pinepods/pinepods_audio_service_parallel_test.dart
@@ -2,8 +2,16 @@
 // 2.0 data in parallel instead of sequentially - before this fix, starting
 // playback paid the cost of both round trips back-to-back.
 //
+// Proves concurrency deterministically (rather than via a wall-clock stopwatch,
+// which is flaky on a loaded CI runner): each mocked call announces it has
+// started, then blocks until the *other* call has also started. If playback ran
+// them sequentially the second call would never start, the first would block
+// forever, and the guard timeout would fail the test fast.
+//
 // Hand-written ("manual") mocks rather than @GenerateMocks-based ones, since
 // this project has no build_runner setup yet.
+
+import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -70,8 +78,6 @@ class MockSettingsBloc extends Mock implements SettingsBloc {
       );
 }
 
-const _perCallDelay = Duration(milliseconds: 100);
-
 void main() {
   test(
     'playPinepodsEpisode fetches podcast id and podcast 2.0 data in parallel, not sequentially',
@@ -91,15 +97,29 @@ void main() {
       when(pinepodsService.getPlayEpisodeDetails(any, any, any)).thenAnswer(
         (_) async => PlayEpisodeDetails(playbackSpeed: 1.0, startSkip: 0, endSkip: 0),
       );
-      // Each of these takes _perCallDelay on its own - if they ran
-      // sequentially the whole call would take roughly 2x that.
+
+      // Each call signals that it has started, then waits for the other to
+      // start before returning. This only resolves if both are in flight at
+      // once; if they were awaited sequentially the second would never begin
+      // and the 5s guard would throw, failing the test rather than hanging.
+      final getPodcastIdStarted = Completer<void>();
+      final fetchData2Started = Completer<void>();
+
+      Future<T> awaitConcurrent<T>(Completer<void> other, String label, T value) async {
+        await other.future.timeout(
+          const Duration(seconds: 5),
+          onTimeout: () => throw StateError('$label did not run concurrently'),
+        );
+        return value;
+      }
+
       when(pinepodsService.getPodcastIdFromEpisode(any, any, any)).thenAnswer((_) async {
-        await Future.delayed(_perCallDelay);
-        return 7;
+        if (!getPodcastIdStarted.isCompleted) getPodcastIdStarted.complete();
+        return awaitConcurrent(fetchData2Started, 'fetchPodcasting2Data', 7);
       });
       when(pinepodsService.fetchPodcasting2Data(any, any)).thenAnswer((_) async {
-        await Future.delayed(_perCallDelay);
-        return <String, dynamic>{};
+        if (!fetchData2Started.isCompleted) fetchData2Started.complete();
+        return awaitConcurrent(getPodcastIdStarted, 'getPodcastIdFromEpisode', <String, dynamic>{});
       });
 
       final episode = PinepodsEpisode(
@@ -118,13 +138,14 @@ void main() {
         isYoutube: false,
       );
 
-      final stopwatch = Stopwatch()..start();
-      await service.playPinepodsEpisode(pinepodsEpisode: episode, resume: false);
-      stopwatch.stop();
+      // Completes only if both fetches overlapped; a sequential regression makes
+      // the guard above throw well within this bound.
+      await service
+          .playPinepodsEpisode(pinepodsEpisode: episode, resume: false)
+          .timeout(const Duration(seconds: 10));
 
-      // Comfortably above the ~100ms parallel case and well below the ~200ms
-      // it would take if the two calls ran one after another.
-      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 180)));
+      expect(getPodcastIdStarted.isCompleted, isTrue);
+      expect(fetchData2Started.isCompleted, isTrue);
     },
   );
 }

--- a/mobile/test/support/factories.dart
+++ b/mobile/test/support/factories.dart
@@ -1,0 +1,102 @@
+// Shared entity builders for tests. Centralizes the "valid-by-default" object
+// construction that individual test files would otherwise each re-declare as a
+// local `_episode(...)`/`_podcast(...)` helper.
+//
+// Episodes default to a concrete [lastUpdated] on purpose: Episode.toMap stores
+// a null lastUpdated as '' which Episode.fromMap can't round-trip (a known
+// pre-existing bug), so leaving it null would break persistence round-trips
+// unrelated to what a test is actually checking.
+
+import 'package:pinepods_mobile/entities/downloadable.dart';
+import 'package:pinepods_mobile/entities/episode.dart';
+import 'package:pinepods_mobile/entities/pinepods_episode.dart';
+import 'package:pinepods_mobile/entities/podcast.dart';
+
+Episode buildEpisode({
+  String guid = 'episode-guid',
+  String? pguid = 'podcast-guid',
+  String? podcast = 'Some Podcast',
+  String? title = 'Some Episode',
+  String? description,
+  String? contentUrl = 'https://example.com/episode.mp3',
+  String? imageUrl,
+  DownloadState downloadState = DownloadState.none,
+  String? filepath,
+  String? filename,
+  int duration = 600,
+  int position = 0,
+  int? downloadPercentage = 0,
+  bool played = false,
+  DateTime? publicationDate,
+  DateTime? lastUpdated,
+}) {
+  return Episode(
+    guid: guid,
+    pguid: pguid,
+    podcast: podcast,
+    title: title,
+    description: description,
+    contentUrl: contentUrl,
+    imageUrl: imageUrl,
+    downloadState: downloadState,
+    filepath: filepath,
+    filename: filename,
+    duration: duration,
+    position: position,
+    downloadPercentage: downloadPercentage,
+    played: played,
+    publicationDate: publicationDate ?? DateTime(2024, 1, 1),
+    lastUpdated: lastUpdated ?? DateTime(2024, 1, 1),
+  );
+}
+
+Podcast buildPodcast({
+  String guid = 'podcast-guid',
+  String url = 'https://example.com/feed.xml',
+  String? link = 'https://example.com',
+  String title = 'Some Podcast',
+  String? description = 'A podcast',
+  List<Episode> episodes = const <Episode>[],
+  DateTime? lastUpdated,
+}) {
+  return Podcast(
+    guid: guid,
+    url: url,
+    link: link,
+    title: title,
+    description: description,
+    episodes: episodes,
+    lastUpdated: lastUpdated ?? DateTime(2024, 1, 1),
+  );
+}
+
+PinepodsEpisode buildPinepodsEpisode({
+  int episodeId = 101,
+  String podcastName = 'Some Podcast',
+  String episodeTitle = 'Some Episode',
+  String episodePubDate = '2024-01-15T14:30:00',
+  int episodeDuration = 600,
+  int? listenDuration,
+  bool completed = false,
+  bool saved = false,
+  bool queued = false,
+  bool downloaded = false,
+  bool isYoutube = false,
+}) {
+  return PinepodsEpisode(
+    podcastName: podcastName,
+    episodeTitle: episodeTitle,
+    episodePubDate: episodePubDate,
+    episodeDescription: 'Description',
+    episodeArtwork: 'https://example.com/art.png',
+    episodeUrl: 'https://example.com/episode.mp3',
+    episodeDuration: episodeDuration,
+    listenDuration: listenDuration,
+    episodeId: episodeId,
+    completed: completed,
+    saved: saved,
+    queued: queued,
+    downloaded: downloaded,
+    isYoutube: isYoutube,
+  );
+}

--- a/mobile/test/support/fakes.dart
+++ b/mobile/test/support/fakes.dart
@@ -1,0 +1,33 @@
+// mocktail mocks for the collaborators that show up across service/bloc tests,
+// plus fallback registration for the entity types used as `any()` arguments.
+//
+// mocktail needs no codegen: `class MockX extends Mock implements X {}` is the
+// whole declaration. Call [registerCommonFallbacks] once in a test's setUpAll
+// before using `any()` with Episode/Podcast arguments.
+
+import 'package:mocktail/mocktail.dart';
+import 'package:pinepods_mobile/entities/episode.dart';
+import 'package:pinepods_mobile/entities/podcast.dart';
+import 'package:pinepods_mobile/services/audio/audio_player_service.dart';
+import 'package:pinepods_mobile/services/podcast/podcast_service.dart';
+
+import 'factories.dart';
+
+class MockPodcastService extends Mock implements PodcastService {}
+
+class MockAudioPlayerService extends Mock implements AudioPlayerService {}
+
+var _fallbacksRegistered = false;
+
+/// Registers fallback values mocktail requires when matching non-primitive
+/// arguments with `any()`. Safe to call more than once.
+void registerCommonFallbacks() {
+  if (_fallbacksRegistered) return;
+  registerFallbackValue(buildEpisode());
+  registerFallbackValue(buildPodcast());
+  _fallbacksRegistered = true;
+}
+
+// Convenience aliases so tests read naturally regardless of the concrete types.
+Episode fallbackEpisode() => buildEpisode();
+Podcast fallbackPodcast() => buildPodcast();

--- a/mobile/test/support/in_memory_repository.dart
+++ b/mobile/test/support/in_memory_repository.dart
@@ -1,0 +1,18 @@
+// Spins up a SembastRepository backed by a fresh in-memory sembast database, so
+// repository (and repository-dependent) tests run without touching disk or the
+// path_provider platform channel.
+//
+// A new factory per call keeps each test fully isolated. `cleanup: false` skips
+// the constructor's fire-and-forget startup cleanup, which would otherwise race
+// with the test body.
+
+import 'package:pinepods_mobile/repository/sembast/sembast_repository.dart';
+import 'package:sembast/sembast_memory.dart';
+
+SembastRepository newInMemoryRepository({bool cleanup = false}) {
+  return SembastRepository(
+    cleanup: cleanup,
+    databaseName: 'test.db',
+    databaseFactory: newDatabaseFactoryMemory(),
+  );
+}


### PR DESCRIPTION
## Summary

Stands up a Flutter test suite that **runs in CI** and covers the mobile app's *business logic* — the layers where user-facing regressions actually live — rather than only its data holders. Goes along with #919 (pure `core/`+`entities/` unit tests), which this is designed to sit on top of.

### CI (the main ask)
- New `.github/workflows/mobile-tests.yml`: runs `flutter analyze` + `flutter test` on `pull_request`/`push` to `main`, **path-filtered to `mobile/**`** so unrelated backend/web/docs PRs don't spin up a Flutter toolchain (matching the `check-i18n.yml`/`openapi.yml` convention).
- `analyze` uses `--no-fatal-infos --no-fatal-warnings` so it blocks on real analyzer **errors** without failing on the ~500 pre-existing style infos/warnings. Tighten once that backlog is cleared.

### Business-logic tests (mocktail, added as a dev dep)
- **Repository** — `sembast_repository_test.dart` drives the real `SembastRepository` against an **in-memory sembast db** (podcasts, episodes, downloads, queue, pending-action offline queue). Enabled by a small seam: `DatabaseService`/`SembastRepository` now accept an injectable `DatabaseFactory` (default disk-backed behavior unchanged).
- **Blocs** — `episode_bloc_test.dart` + `queue_bloc_test.dart` exercise the hand-rolled **rxdart** blocs (this app doesn't use `flutter_bloc`, so no `bloc_test`) by pushing input sinks and asserting emitted `BlocState` streams via `emitsInOrder`, plus mocked-service interactions.
- Shared `test/support/` scaffolding: entity factories, mocktail fakes, in-memory repo helper.

## Notes
- Two pre-existing `Episode` bugs surfaced by #919 (null-`lastUpdated` round-trip `FormatException`; `==`/`hashCode` contract mismatch) are still open and worth a separate fix.
- `saveQueue` fire-and-forgets `_saveEpisode` for ad-hoc episodes — a latent race the repository test works around; also worth a follow-up.