### PR TITLE
Mobile: fix Episode date round-trip, equals/hashCode, and saveQueue race

### DIFF
--- a/mobile/lib/entities/episode.dart
+++ b/mobile/lib/entities/episode.dart
@@ -205,8 +205,20 @@ class Episode {
       'tid': transcriptId ?? 0,
       'transcriptUrls': (transcriptUrls).map((tu) => tu.toMap()).toList(growable: false),
       'persons': (persons).map((person) => person.toMap()).toList(growable: false),
-      'lastUpdated': lastUpdated?.millisecondsSinceEpoch.toString() ?? '',
+      'lastUpdated': lastUpdated?.millisecondsSinceEpoch.toString(),
     };
+  }
+
+  /// Parses an epoch-milliseconds value that was stored as a string, tolerating
+  /// the several ways "absent" has been serialized over time (a real null, the
+  /// literal string 'null', or an empty string - the last of which older
+  /// [toMap] output produced for a null date and which [int.parse] would throw
+  /// a FormatException on). Falls back to [DateTime.now] when absent.
+  static DateTime _parseStoredDate(Object? value) {
+    if (value == null || value == 'null' || value == '') {
+      return DateTime.now();
+    }
+    return DateTime.fromMillisecondsSinceEpoch(int.parse(value as String));
   }
 
   static Episode fromMap(int? key, Map<String, dynamic> episode) {
@@ -255,9 +267,7 @@ class Episode {
       link: episode['link'] as String?,
       imageUrl: episode['imageUrl'] as String?,
       thumbImageUrl: episode['thumbImageUrl'] as String?,
-      publicationDate: episode['publicationDate'] == null || episode['publicationDate'] == 'null'
-          ? DateTime.now()
-          : DateTime.fromMillisecondsSinceEpoch(int.parse(episode['publicationDate'] as String)),
+      publicationDate: _parseStoredDate(episode['publicationDate']),
       contentUrl: episode['contentUrl'] as String?,
       author: episode['author'] as String?,
       season: int.parse(episode['season'] as String? ?? '0'),
@@ -271,9 +281,7 @@ class Episode {
       transcriptUrls: transcriptUrls,
       persons: persons,
       transcriptId: episode['tid'] == null ? 0 : episode['tid'] as int?,
-      lastUpdated: episode['lastUpdated'] == null || episode['lastUpdated'] == 'null'
-          ? DateTime.now()
-          : DateTime.fromMillisecondsSinceEpoch(int.parse(episode['lastUpdated'] as String)),
+      lastUpdated: _parseStoredDate(episode['lastUpdated']),
     );
   }
 
@@ -331,35 +339,40 @@ class Episode {
             listEquals(chapters, other.chapters);
   }
 
+  // Mirrors the fields compared in `==` exactly, so the equals/hashCode
+  // contract holds: `id` and `lastUpdated` are deliberately excluded (as in
+  // `==`), publicationDate is hashed by its epoch-millis (as `==` compares it),
+  // and `persons`/`chapters` are content-hashed to match their `listEquals`
+  // comparison rather than hashed by list identity.
   @override
-  int get hashCode =>
-      id.hashCode ^
-      guid.hashCode ^
-      pguid.hashCode ^
-      downloadTaskId.hashCode ^
-      filepath.hashCode ^
-      filename.hashCode ^
-      downloadState.hashCode ^
-      podcast.hashCode ^
-      title.hashCode ^
-      description.hashCode ^
-      content.hashCode ^
-      link.hashCode ^
-      imageUrl.hashCode ^
-      thumbImageUrl.hashCode ^
-      publicationDate.hashCode ^
-      contentUrl.hashCode ^
-      author.hashCode ^
-      season.hashCode ^
-      episode.hashCode ^
-      duration.hashCode ^
-      position.hashCode ^
-      downloadPercentage.hashCode ^
-      played.hashCode ^
-      chaptersUrl.hashCode ^
-      chapters.hashCode ^
-      transcriptId.hashCode ^
-      lastUpdated.hashCode;
+  int get hashCode => Object.hashAll([
+        guid,
+        pguid,
+        downloadTaskId,
+        filepath,
+        filename,
+        downloadState,
+        podcast,
+        title,
+        description,
+        content,
+        link,
+        imageUrl,
+        thumbImageUrl,
+        publicationDate?.millisecondsSinceEpoch,
+        contentUrl,
+        author,
+        season,
+        episode,
+        duration,
+        position,
+        downloadPercentage,
+        played,
+        chaptersUrl,
+        transcriptId,
+        Object.hashAll(persons),
+        Object.hashAll(chapters),
+      ]);
 
   @override
   String toString() {

--- a/mobile/lib/repository/sembast/sembast_repository.dart
+++ b/mobile/lib/repository/sembast/sembast_repository.dart
@@ -403,10 +403,14 @@ class SembastRepository extends Repository {
 
   @override
   Future<void> saveQueue(List<Episode> episodes) async {
-    /// Check to see if we have any ad-hoc episodes and save them first
+    /// Check to see if we have any ad-hoc episodes and save them first. These
+    /// must be awaited: the queue record we write below only stores guids, so if
+    /// the episodes aren't persisted before saveQueue returns, a subsequent
+    /// loadQueue (or an app restart) finds the queue referencing episodes that
+    /// don't exist yet.
     for (var e in episodes) {
       if (e.pguid == null || e.pguid!.isEmpty) {
-        _saveEpisode(e, false);
+        await _saveEpisode(e, false);
       }
     }
 

--- a/mobile/test/entities/episode_roundtrip_test.dart
+++ b/mobile/test/entities/episode_roundtrip_test.dart
@@ -1,0 +1,92 @@
+// Regression tests for two Episode bugs:
+//  1. A null lastUpdated used to serialize as '' and then throw a
+//     FormatException on the way back in (int.parse('')).
+//  2. hashCode included id/lastUpdated (and hashed chapters/persons by list
+//     identity) while == did not, violating the equals/hashCode contract.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinepods_mobile/entities/chapter.dart';
+import 'package:pinepods_mobile/entities/episode.dart';
+
+Episode _episode({
+  int? id,
+  DateTime? lastUpdated,
+  List<Chapter> chapters = const <Chapter>[],
+}) {
+  return Episode(
+    id: id,
+    guid: 'guid-1',
+    pguid: 'podcast-guid',
+    podcast: 'Some Podcast',
+    title: 'Some Episode',
+    publicationDate: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+    lastUpdated: lastUpdated,
+    chapters: chapters,
+  );
+}
+
+void main() {
+  group('lastUpdated round-trip (bug 1)', () {
+    test('an episode with a null lastUpdated survives toMap -> fromMap', () {
+      final map = _episode(lastUpdated: null).toMap();
+
+      // Previously int.parse('') threw here.
+      final restored = Episode.fromMap(1, map);
+
+      expect(restored.lastUpdated, isNotNull);
+    });
+
+    test('a legacy empty-string lastUpdated is treated as absent, not parsed', () {
+      final map = _episode(lastUpdated: DateTime(2024)).toMap();
+      map['lastUpdated'] = ''; // simulate data written by the old toMap
+
+      expect(() => Episode.fromMap(1, map), returnsNormally);
+    });
+
+    test('a concrete lastUpdated still round-trips exactly', () {
+      final when = DateTime.fromMillisecondsSinceEpoch(1700000005000);
+      final restored = Episode.fromMap(1, _episode(lastUpdated: when).toMap());
+      expect(restored.lastUpdated, when);
+    });
+
+    test('an empty-string publicationDate is also handled defensively', () {
+      final map = _episode().toMap();
+      map['publicationDate'] = '';
+      expect(() => Episode.fromMap(1, map), returnsNormally);
+    });
+  });
+
+  group('equals/hashCode contract (bug 2)', () {
+    test('episodes equal by == have equal hashCodes despite differing id', () {
+      final a = _episode(id: 1, lastUpdated: DateTime(2024, 1, 1));
+      final b = _episode(id: 2, lastUpdated: DateTime(2024, 1, 1));
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('episodes equal by == have equal hashCodes despite differing lastUpdated', () {
+      final a = _episode(id: 1, lastUpdated: DateTime(2024, 1, 1));
+      final b = _episode(id: 1, lastUpdated: DateTime(2025, 6, 30));
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('an equal episode is found in a HashSet keyed on Episode', () {
+      final stored = _episode(id: 1, lastUpdated: DateTime(2024, 1, 1));
+      final lookup = _episode(id: 99, lastUpdated: DateTime(2030, 1, 1));
+
+      final set = {stored};
+      expect(set.contains(lookup), isTrue);
+    });
+
+    test('equal chapter *content* in distinct list instances still hashes equally', () {
+      final a = _episode(chapters: [Chapter(title: 'Intro', imageUrl: null, startTime: 0)]);
+      final b = _episode(chapters: [Chapter(title: 'Intro', imageUrl: null, startTime: 0)]);
+
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+}

--- a/mobile/test/repository/sembast_repository_test.dart
+++ b/mobile/test/repository/sembast_repository_test.dart
@@ -102,10 +102,8 @@ void main() {
   });
 
   group('queue', () {
-    test('saveQueue then loadQueue round-trips the queued episodes', () async {
-      // Persist the episodes first, then queue them. (saveQueue only persists
-      // ad-hoc/empty-pguid episodes, and does so without awaiting - so saving
-      // explicitly keeps this test about the queue round-trip, not that race.)
+    test('saveQueue then loadQueue round-trips already-saved episodes', () async {
+      // Regular (non-ad-hoc) episodes are persisted independently, then queued.
       final a = await repo.saveEpisode(buildEpisode(guid: 'q1'));
       final b = await repo.saveEpisode(buildEpisode(guid: 'q2'));
 
@@ -113,6 +111,19 @@ void main() {
 
       final loaded = await repo.loadQueue();
       expect(loaded.map((e) => e.guid), containsAll(['q1', 'q2']));
+    });
+
+    test('saveQueue persists ad-hoc (empty-pguid) episodes so loadQueue finds them', () async {
+      // Ad-hoc episodes are saved by saveQueue itself. This used to be
+      // fire-and-forget, so the queue record could reference episodes that
+      // weren't persisted yet; loadQueue must now find them.
+      final a = buildEpisode(guid: 'adhoc1', pguid: '');
+      final b = buildEpisode(guid: 'adhoc2', pguid: '');
+
+      await repo.saveQueue([a, b]);
+
+      final loaded = await repo.loadQueue();
+      expect(loaded.map((e) => e.guid), containsAll(['adhoc1', 'adhoc2']));
     });
 
     test('loadQueue is empty when nothing has been queued', () async {


### PR DESCRIPTION
Fixes three pre-existing bugs surfaced while building the mobile test suite. Each has a regression test.

> **Stacked on #924** (base is `test/mobile-ci-and-coverage`, not `main`) because the repository fix's test relies on the in-memory-sembast test infra added there. Merge after #924, or I'll rebase onto `main` once it lands. The Episode fixes are independent of that infra.

### 1. `Episode` null `lastUpdated` round-trips into a `FormatException`
`toMap` stored a null `lastUpdated` as `''`; `fromMap`'s null-check only caught `null`/`'null'`, so `int.parse('')` threw on reload. `toMap` now writes `null`, and a shared `_parseStoredDate` helper treats `null`/`'null'`/`''` as absent (also hardening the `publicationDate` path against any legacy `''` already on disk).

### 2. `Episode` `==` / `hashCode` violate the contract
`hashCode` mixed in `id` and `lastUpdated` — which `==` deliberately ignores — and hashed `chapters`/`persons` by list identity while `==` compares them with `listEquals`. So two `==`-equal episodes could produce different hash codes and be missed in a `HashSet`/`HashMap`. `hashCode` now mirrors `==` exactly via `Object.hashAll`.

### 3. `SembastRepository.saveQueue` fire-and-forgets episode saves
Ad-hoc (empty-`pguid`) episodes were persisted with an un-awaited `_saveEpisode`, so the queue record — which stores only guids — could be written before those episodes existed. An immediate `loadQueue` (or an app restart) would then reference episodes that were never saved. The saves are now awaited.

## Test plan
- [x] `flutter test` — 73/73 pass (Flutter 3.44.5 stable), incl. new regression tests:
  - null / legacy-`''` `lastUpdated` round-trip; concrete-value round-trip; `''` `publicationDate`
  - `==`/`hashCode` equal across differing `id` and `lastUpdated`; `HashSet.contains`; equal chapter content in distinct list instances
  - `saveQueue` persists ad-hoc episodes so `loadQueue` finds them
- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` — exit 0