### PR TITLE
fix(mobile): preserve episode sort and filter after list actions

### DIFF
--- a/mobile/lib/ui/pinepods/podcast_details.dart
+++ b/mobile/lib/ui/pinepods/podcast_details.dart
@@ -1003,9 +1003,7 @@ class _PinepodsPodcastDetailsState extends State<PinepodsPodcastDetails> {
       if (success) {
         setState(() {
           _episodes[episodeIndex] = _updateEpisodeProperty(episode, saved: true);
-          _filteredEpisodes = _episodes.where((e) => 
-            e.episodeTitle.toLowerCase().contains(_searchController.text.toLowerCase())
-          ).toList();
+          _filterEpisodes();
         });
         _showSnackBar('Episode saved!', Colors.green);
       } else {
@@ -1041,9 +1039,7 @@ class _PinepodsPodcastDetailsState extends State<PinepodsPodcastDetails> {
       if (success) {
         setState(() {
           _episodes[episodeIndex] = _updateEpisodeProperty(episode, saved: false);
-          _filteredEpisodes = _episodes.where((e) => 
-            e.episodeTitle.toLowerCase().contains(_searchController.text.toLowerCase())
-          ).toList();
+          _filterEpisodes();
         });
         _showSnackBar('Removed from saved episodes', Colors.orange);
       } else {
@@ -1079,9 +1075,7 @@ class _PinepodsPodcastDetailsState extends State<PinepodsPodcastDetails> {
       if (success) {
         setState(() {
           _episodes[episodeIndex] = _updateEpisodeProperty(episode, downloaded: true);
-          _filteredEpisodes = _episodes.where((e) => 
-            e.episodeTitle.toLowerCase().contains(_searchController.text.toLowerCase())
-          ).toList();
+          _filterEpisodes();
         });
         _showSnackBar('Episode download started!', Colors.green);
       } else {
@@ -1117,9 +1111,7 @@ class _PinepodsPodcastDetailsState extends State<PinepodsPodcastDetails> {
       if (success) {
         setState(() {
           _episodes[episodeIndex] = _updateEpisodeProperty(episode, downloaded: false);
-          _filteredEpisodes = _episodes.where((e) => 
-            e.episodeTitle.toLowerCase().contains(_searchController.text.toLowerCase())
-          ).toList();
+          _filterEpisodes();
         });
         _showSnackBar('Episode deleted from server', Colors.orange);
       } else {
@@ -1156,9 +1148,7 @@ class _PinepodsPodcastDetailsState extends State<PinepodsPodcastDetails> {
         if (success) {
           setState(() {
             _episodes[episodeIndex] = _updateEpisodeProperty(episode, queued: false);
-            _filteredEpisodes = _episodes.where((e) => 
-              e.episodeTitle.toLowerCase().contains(_searchController.text.toLowerCase())
-            ).toList();
+            _filterEpisodes();
           });
           _showSnackBar('Removed from queue', Colors.orange);
         }
@@ -1171,9 +1161,7 @@ class _PinepodsPodcastDetailsState extends State<PinepodsPodcastDetails> {
         if (success) {
           setState(() {
             _episodes[episodeIndex] = _updateEpisodeProperty(episode, queued: true);
-            _filteredEpisodes = _episodes.where((e) => 
-              e.episodeTitle.toLowerCase().contains(_searchController.text.toLowerCase())
-            ).toList();
+            _filterEpisodes();
           });
           _showSnackBar('Added to queue!', Colors.green);
         }


### PR DESCRIPTION
On the podcast details page, every per-episode action (save, remove-saved, download, delete, add-to-queue, remove-from-queue) rebuilt the visible list with only the search filter, silently dropping the active sort order and completed filter back to their defaults. Those six handlers in `podcast_details.dart` now route through `_filterEpisodes()`, the same path `_markEpisodeComplete()` already used, which reapplies search, completed filter, and sort.