### PR TITLE
Fix play/pause button desync on episode rows (#449)

### DIFF
--- a/web/src/components/episode_list_item.rs
+++ b/web/src/components/episode_list_item.rs
@@ -223,16 +223,15 @@ pub fn episode_list_item(props: &EpisodeListItemProps) -> Html {
                 .as_ref()
                 .map_or(false, |cp| cp.episode_id == episode.episodeid);
             if is_current {
+                // Toggle the ACTIVE media element. The previous code only handled the legacy
+                // `audio_element`, which is `None` for streamed playback; both RSS audio and
+                // YouTube video play through `media_element`. As a result the click flipped
+                // `audio_playing` without ever pausing/resuming the media, leaving the row's
+                // play/pause button out of sync with playback (issue #449). `toggle_playback`
+                // prefers `media_element` and falls back to `audio_element`, and the media
+                // element's play/pause event listeners keep `audio_playing` in sync afterwards.
                 audio_dispatch.reduce_mut(|state| {
-                    let currently_playing = state.audio_playing.unwrap_or(false);
-                    state.audio_playing = Some(!currently_playing);
-                    if let Some(audio) = &state.audio_element {
-                        if currently_playing {
-                            let _ = audio.pause();
-                        } else {
-                            let _ = audio.play();
-                        }
-                    }
+                    state.toggle_playback();
                 });
             } else {
                 let episode_id = episode.episodeid;


### PR DESCRIPTION
## Summary

Fixes #449. On the episode list, clicking the play/pause button of the episode that is *currently playing* does not actually pause or resume it, and the button icon stays out of sync with playback. It was reported against YouTube channels, but the same handler affects RSS audio.

## Root cause

The currently-playing branch of the row handler in `web/src/components/episode_list_item.rs` only acted on the legacy `audio_element` slot:

```rust
audio_dispatch.reduce_mut(|state| {
    let currently_playing = state.audio_playing.unwrap_or(false);
    state.audio_playing = Some(!currently_playing);
    if let Some(audio) = &state.audio_element {
        if currently_playing { let _ = audio.pause(); } else { let _ = audio.play(); }
    }
});
```

`audio_element` is `None` for streamed playback. Both RSS audio and YouTube video play through `media_element` (populated by `UIState::set_media_source`); `audio_element` is only ever populated by the shared-episode page's legacy path, and the player's `audio_ref` is never bound to a rendered `<audio>` element. So this handler flipped `audio_playing`, but the `if let Some(audio) = &state.audio_element` body never ran: the media was never paused or resumed, and because no real `play`/`pause` event fired on the media element, the listeners that `set_media_source` attaches never corrected the flag. The row icon (`is_current && audio_playing`) then desynced from actual playback, which is exactly #449 ("Play Button Doesn't update on Youtube Channel Page").

This is the only toggle in `web/src` that used `audio_element` alone; every other one (`context.rs::toggle_playback`, `audio.rs::toggle_playback`, `episode.rs`, `safehtml.rs`) already prefers `media_element` with `audio_element` as a fallback.

## Fix

Delegate to the canonical `UIState::toggle_playback`, which prefers `media_element`, falls back to `audio_element`, actually pauses or resumes the active element, and sets `audio_playing` (then reinforced by the media element's existing `play`/`pause` listeners). This is the same method the player-level `on_play_pause` in `audio.rs` already uses, so it is idiomatic here.

One hunk, +8/-9, no API change. For the legacy audio-only case it behaves identically to the old code, so it cannot regress that path; it also handles the `media_element` case the old code ignored, which is what RSS and YouTube playback actually use.

## Testing

- Built to `wasm32-unknown-unknown` with the repo's `RUSTFLAGS` on `rust:alpine` (the same base as the frontend build stage).
- Manually verified in a running deployment: on the episode list, the play/pause button now correctly pauses and resumes the currently-playing episode and stays in sync with playback, confirmed for both a YouTube episode and a standard RSS podcast.

## Note (out of scope)

While tracing this, one adjacent thing stood out: in the play-start path in `audio.rs`, the error branches of the podcast-id and play-details lookups start no playback and only clear the loading state, so if either call fails for an episode, playback silently never begins. That is a separate, backend-dependent path and is not touched here.
