### PR TITLE
fix(startup): keep nginx temp dirs owned by the nginx worker user

### DIFF
--- a/startup/startup.sh
+++ b/startup/startup.sh
@@ -182,6 +182,34 @@ cp /pinepods/startup/services/*.toml /etc/horust/services/
 # Horust creates a unix-domain-socket folder at /var/run/horust; nginx needs its own dirs.
 mkdir -p /run/nginx /var/lib/nginx/tmp /var/log/nginx /var/run/horust
 
+# nginx's own directories belong to whoever its worker processes end up running
+# as, which is not always PUID. This image replaces the packaged nginx.conf,
+# and ours carries no 'user' directive, so nginx falls back to its compile-time
+# default (--user=nginx): a master started as root drops its workers to the
+# 'nginx' user. Handing /var/lib/nginx/tmp to anyone else (mode 0700) leaves
+# those workers unable to create proxy temp files, and nginx then truncates any
+# upstream response too large for its in-memory buffers instead of failing.
+# The client just gets malformed JSON; the only trace is a
+# "[crit] ... (13: Permission denied) while reading upstream" line in
+# /var/log/nginx/error.log, which nothing surfaces because horust captures only
+# nginx's stdout/stderr (startup/services/nginx.toml).
+#
+# The condition mirrors the privilege-drop guard below on purpose: privileges
+# are only dropped when BOTH PUID and PGID are set, so PUID alone still leaves
+# a root master whose workers are 'nginx'. Testing PUID by itself here would
+# hand the dirs to PUID while nginx ran as 'nginx' — the same bug, reintroduced.
+# The zero test matches any all-zero spelling, not just the string "0":
+# chown and su-exec both parse "00" and "000" as uid 0, so a plain string
+# compare would hand the dirs to root while the master stayed root and its
+# workers dropped to 'nginx' -- the same bug, in the one case this guard exists
+# to catch.
+if [[ -n "$PUID" && -n "$PGID" && ! "$PUID" =~ ^0+$ ]]; then
+    nginx_owner="${PUID}:${PGID}"
+else
+    nginx_owner="nginx:nginx"
+fi
+chown -R "$nginx_owner" /run/nginx /var/lib/nginx /var/log/nginx 2>/dev/null || true
+
 # When PUID/PGID are set, drop privileges and run the whole stack as that user so files
 # are created with correct ownership natively (no per-file chown needed). Otherwise run as root.
 if [[ -n "$PUID" && -n "$PGID" ]]; then
@@ -195,10 +223,11 @@ if [[ -n "$PUID" && -n "$PGID" ]]; then
     # Cheap, non-recursive ownership of the dirs the app writes to.
     # Note: local-media is intentionally chowned non-recursively — it's often a large
     # pre-existing library; the app only needs to write artwork into a subdir.
+    # nginx's dirs are deliberately absent here — they are set above to the user
+    # nginx actually runs its workers as, which is not PUID when the master is root.
     chown "${PUID}:${PGID}" /pinepods/cache /var/log/pinepods /opt/pinepods/certs \
                             /opt/pinepods/downloads /opt/pinepods/backups \
                             /opt/pinepods/local-media \
-                            /run/nginx /var/lib/nginx /var/lib/nginx/tmp /var/log/nginx \
                             /var/run/horust 2>/dev/null || true
 
     # One-time recursive migration of pre-existing root-owned content, gated by a marker


### PR DESCRIPTION

The PUID/PGID chown added in 123ae005a0 included /var/lib/nginx and
/var/lib/nginx/tmp. These images replace the packaged nginx.conf
(dockerfile:174, dockerfile-arm:165) and ours carries no 'user'
directive, so nginx uses its compile-time default and a master started as
root drops its workers to the 'nginx' user (uid 100). With PUID=0 the
temp tree therefore ends up root:root mode 0700 and those workers cannot
create proxy temp files:

    [crit] open() "/var/lib/nginx/tmp/proxy/0/10/0000000100" failed
           (13: Permission denied) while reading upstream

When that happens nginx serves what it already has instead of failing, so
the client gets a short body with HTTP 200. Reported on
/api/data/podcast_episodes, where the mobile app parses the truncated
JSON, throws, and renders an empty list.

Response size alone does not trigger it, which is why it looks
intermittent: nginx only needs a temp file when it has to buffer ahead of
the client, so the same endpoint can return intact for a client that
drains as fast as the upstream delivers and truncate for a slower one.
The one log line it does produce goes to /var/log/nginx/error.log, which
nothing surfaces because horust captures only nginx's stdout/stderr
(startup/services/nginx.toml).

Only a root master can setuid. When privileges are actually dropped the
workers inherit PUID and the original chown was right, so the owner is
chosen rather than hard-coded:

  privileges dropped (PUID and PGID set, PUID non-zero) -> PUID:PGID
  otherwise (master stays root)                         -> nginx:nginx

The condition mirrors the privilege-drop guard below it, including the
PGID check: PUID set without PGID does NOT drop privileges, so the master
stays root and its workers are still 'nginx'. Testing PUID alone would
hand the dirs to PUID while nginx ran as 'nginx', reproducing the bug in
a configuration that works on main today. The zero test matches any
all-zero spelling for the same reason, since chown and su-exec both read
"00" as uid 0.

nginx's directories are removed from the PUID chown list so the two
cannot disagree.

Fixes #940


---

### Verification

Rebuilt the relevant slice of the image (alpine + nginx, an nginx.conf with no `user` directive, a 20MB upstream body) and ran the branch logic directly, then forced nginx to spill to a proxy temp file with a rate-limited client.

Negative control, ownership broken with a root master: **7,008,182 of 20,263,158 bytes**, HTTP 200, with the `[crit] ... 13: Permission denied` line quoted above.

Every PUID/PGID combination after the fix:

| PUID | PGID | owner picked | master | worker | result |
|---|---|---|---|---|---|
| unset | unset | nginx:nginx | root | nginx | OK |
| 0 | 0 | nginx:nginx | root | nginx | OK |
| 1000 | 1000 | 1000:1000 | pinepods | pinepods | OK |
| 911 | 911 | 911:911 | pinepods | pinepods | OK (compose default) |
| 1000 | unset | nginx:nginx | root | nginx | OK |
| unset | 1000 | nginx:nginx | root | nginx | OK |
| 0 | 1000 | nginx:nginx | root | nginx | OK |
| 1000 | 0 | 1000:0 | pinepods | pinepods | OK |
| 100 | 101 | 100:101 | nginx | nginx | OK |
| 00 / 000 | 0 | nginx:nginx | root | nginx | OK |

Also checked: `chown -R` does not traverse the package's symlinks (`/var/lib/nginx/logs`, `modules`, `run`) since busybox chown does not dereference them, so no system files are touched; the recursion is load-bearing across restarts with a named volume on `/var/lib/nginx`, correcting stale ownership in both directions; and nothing else in the repo references these paths.
