### PR TITLE
fix: refresh queue panel immediately after queue add/remove

### DIFF
--- a/web/src/components/context_menu_button.rs
+++ b/web/src/components/context_menu_button.rs
@@ -11,11 +11,12 @@ use crate::requests::episode::Episode;
 use crate::components::gen_funcs::format_error_message;
 use crate::requests::pod_req::{
     call_add_episode_to_collection, call_download_episode, call_get_collection_add_ui,
-    call_get_collections, call_get_episode_collections, call_mark_episode_completed,
-    call_mark_episode_uncompleted, call_queue_episode, call_remove_downloaded_episode,
-    call_remove_episode_from_collection, call_remove_queued_episode, call_remove_saved_episode,
-    call_save_episode, Collection, CollectionEpisodeRequest, DownloadEpisodeRequest,
-    MarkEpisodeCompletedRequest, QueuePodcastRequest, SavePodcastRequest,
+    call_get_collections, call_get_episode_collections, call_get_queued_episodes,
+    call_mark_episode_completed, call_mark_episode_uncompleted, call_queue_episode,
+    call_remove_downloaded_episode, call_remove_episode_from_collection,
+    call_remove_queued_episode, call_remove_saved_episode, call_save_episode, Collection,
+    CollectionEpisodeRequest, DownloadEpisodeRequest, MarkEpisodeCompletedRequest,
+    QueuePodcastRequest, QueuedEpisodesResponse, SavePodcastRequest,
 };
 use std::collections::HashSet;
 #[cfg(not(feature = "server_build"))]
@@ -383,14 +384,27 @@ pub fn context_button(props: &ContextButtonProps) -> Html {
             let server_name = server_name_copy; // replace with the actual server name
             let api_key = api_key_copy; // replace with the actual API key
             let future = async move {
-                match call_queue_episode(&server_name.unwrap(), &api_key.flatten(), &request).await
-                {
+                let server = server_name.unwrap();
+                let key = api_key.flatten();
+                let uid = request.user_id;
+                match call_queue_episode(&server, &key, &request).await {
                     Ok(success_message) => {
                         Dispatch::<EpisodeStatusState>::global().reduce_mut(|state| {
                             if let Some(ref mut queued_episodes) = state.queued_episode_ids {
                                 queued_episodes.push(episode_clone.episodeid);
                             }
                         });
+                        if let Ok(mut eps) =
+                            call_get_queued_episodes(&server, &key, &uid).await
+                        {
+                            eps.sort_by_key(|e| e.queueposition.unwrap_or(i32::MAX));
+                            let ids: Vec<i32> = eps.iter().map(|e| e.episodeid).collect();
+                            Dispatch::<EpisodeStatusState>::global().reduce_mut(move |state| {
+                                state.queued_episodes =
+                                    Some(QueuedEpisodesResponse { episodes: eps });
+                                state.queued_episode_ids = Some(ids);
+                            });
+                        }
                         Dispatch::<NotificationState>::global().reduce_mut(|state| {
                             state.info_message = Option::from(format!("{}", success_message));
                         });

--- a/web/src/components/queue_panel.rs
+++ b/web/src/components/queue_panel.rs
@@ -426,10 +426,13 @@ pub fn queue_panel() -> Html {
                                                 eps.sort_by_key(|e| {
                                                     e.queueposition.unwrap_or(i32::MAX)
                                                 });
+                                                let ids: Vec<i32> =
+                                                    eps.iter().map(|e| e.episodeid).collect();
                                                 dispatch.reduce_mut(|s| {
                                                     s.queued_episodes = Some(
                                                         QueuedEpisodesResponse { episodes: eps },
                                                     );
+                                                    s.queued_episode_ids = Some(ids);
                                                 });
                                             }
                                         });

--- a/web/src/requests/pod_req.rs
+++ b/web/src/requests/pod_req.rs
@@ -2410,6 +2410,7 @@ pub async fn call_bulk_queue_episodes(
         .await?;
 
     if response.ok() {
+        cache::invalidate_prefix(&format!("{}/api/data/get_queued_episodes", server_name));
         let response_body: BulkEpisodeActionResponse =
             response.json().await.map_err(|e| anyhow::Error::new(e))?;
         Ok(response_body.message)


### PR DESCRIPTION
## Summary

Fixes #873 — the Queue panel in the web UI did not refresh automatically after adding to or removing from the queue; the change only appeared after a full page reload.

## Root cause

Adding an episode to the queue (from the context menu) updated `EpisodeStatusState::queued_episode_ids` but never refreshed `queued_episodes` — the field the Queue panel actually renders from. So the panel kept showing the stale list until a reload re-fetched it.

## Changes

- **`web/src/components/context_menu_button.rs`** — after a successful `call_queue_episode`, re-fetch the queued episodes via `call_get_queued_episodes` and update both `queued_episodes` and `queued_episode_ids` in shared state, so the panel re-renders immediately. (Remove-via-context-menu already did an in-place retain on both fields, so it was fine.)
- **`web/src/components/queue_panel.rs`** — when the in-panel remove (X) re-fetches the queue, also update `queued_episode_ids` alongside `queued_episodes` so the two stay consistent.
- **`web/src/requests/pod_req.rs`** — invalidate the `get_queued_episodes` cache prefix inside `call_bulk_queue_episodes` so bulk-queue actions don't serve a stale cached list.

## Verification

- `cargo check --target wasm32-unknown-unknown --features server_build` — clean (only pre-existing warnings).
