### PR TITLE
fix: handle missing subscription metadata

### DIFF
--- a/rust-api/src/handlers/settings.rs
+++ b/rust-api/src/handlers/settings.rs
@@ -3259,8 +3259,25 @@ pub async fn update_startpage(
 #[derive(Deserialize, utoipa::ToSchema)]
 pub struct PersonSubscribeRequest {
     pub person_name: String,
-    pub person_img: String,
+    pub person_img: Option<String>,
     pub podcast_id: i32,
+}
+
+#[cfg(test)]
+mod person_subscribe_request_tests {
+    use super::PersonSubscribeRequest;
+
+    #[test]
+    fn accepts_missing_person_image() {
+        let request: PersonSubscribeRequest = serde_json::from_value(serde_json::json!({
+            "person_name": "Host Without Artwork",
+            "person_img": null,
+            "podcast_id": 1
+        }))
+        .expect("null host artwork should deserialize");
+
+        assert_eq!(request.person_img, None);
+    }
 }
 
 // Request struct for person unsubscribe
@@ -3304,7 +3321,7 @@ pub async fn subscribe_to_person(
         user_id,
         person_id,
         &request.person_name,
-        &request.person_img,
+        request.person_img.as_deref().unwrap_or(""),
         request.podcast_id,
     ).await?;
 
@@ -6304,4 +6321,3 @@ pub async fn delete_custom_theme(
     state.db_pool.delete_custom_theme(request.theme_id, request.user_id).await?;
     Ok(Json(serde_json::json!({ "message": "Custom theme deleted successfully" })))
 }
-

--- a/web/src/pages/episode_layout.rs
+++ b/web/src/pages/episode_layout.rs
@@ -3886,7 +3886,11 @@ pub fn episode_layout() -> Html {
                 let pod_title_og = pod_values.clone().unwrap().podcastname.clone();
                 let pod_artwork_og = pod_values.clone().unwrap().artworkurl.clone();
                 let pod_author_og = pod_values.clone().unwrap().author.clone();
-                let categories_og = pod_values.clone().unwrap().categories.unwrap().clone();
+                let categories_og = pod_values
+                    .clone()
+                    .unwrap()
+                    .categories
+                    .unwrap_or_default();
                 let pod_description_og = pod_values.clone().unwrap().description.clone();
                 let pod_episode_count_og = pod_values.clone().unwrap().episodecount.clone();
                 let pod_feed_url_og = pod_values.clone().unwrap().feedurl.clone();


### PR DESCRIPTION
## Summary

- accept `person_img: null` when subscribing to hosts without artwork
- treat missing podcast categories as an empty map when subscribing from podcast details
- add a regression test for null host artwork deserialization

## Problem

The web client serializes an absent host image as `null`, while the API expected a required `String`. Axum rejected the request with HTTP 422 before authorization or database handling.

Podcast metadata can also contain `categories: null`. The details-page subscribe callback unwrapped that optional field, causing a WebAssembly panic before it sent `POST /api/data/add_podcast`; clicking Subscribe therefore appeared to do nothing.

## Validation

- `cargo test accepts_missing_person_image` with Rust 1.95
- production web bundle builds successfully with Trunk
- replayed both null-metadata paths against PinePods 0.9.0
- confirmed host and podcast subscriptions persisted in PostgreSQL