### PR TITLE
docs: document the Valkey/Redis startup prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ accounts there are wiped periodically, so run your own server for real use.
 
 ## Quick Start :rocket:
 
+PinePods requires a database (PostgreSQL or MySQL/MariaDB) and a reachable Valkey
+or Redis server. The API connects to Valkey/Redis before it starts listening.
+Keep the `valkey` service below unless you configure an external server.
+
 The fastest way to run PinePods is Docker Compose with PostgreSQL. Create a
 `docker-compose.yml`:
 
@@ -174,6 +178,16 @@ services:
       - db
       - valkey
 ```
+
+For an external Valkey/Redis server, set `VALKEY_HOST` and `VALKEY_PORT` on the
+`pinepods` service to an address it can reach. Set `VALKEY_PASSWORD` if the server
+requires password authentication, and `VALKEY_USERNAME` if it uses a named user.
+Remove the local `valkey` service and its `depends_on` entry when using an
+external server.
+
+If Valkey/Redis is unavailable at startup, the API cannot serve `/api/health`.
+Nginx can return `502` for that endpoint while the web page still loads. Check
+the Valkey/Redis service and its connection settings if you encounter this.
 
 Then start it:
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ requires password authentication, and `VALKEY_USERNAME` if it uses a named user.
 Remove the local `valkey` service and its `depends_on` entry when using an
 external server.
 
-If Valkey/Redis is unavailable at startup, the API cannot serve `/api/health`.
-Nginx can return `502` for that endpoint while the web page still loads. Check
+If Valkey/Redis is unavailable at startup, the API cannot start. Nginx can return
+`502` for API requests, including `/api/health`, while the web page still loads. Check
 the Valkey/Redis service and its connection settings if you encounter this.
 
 Then start it:


### PR DESCRIPTION
The Quick Start includes a Valkey service but does not say it is required. The API opens its Valkey/Redis connection before it starts listening, so a missing service also leaves `/api/health` unavailable even when nginx serves the web page.

Document the prerequisite before the Compose example, explain how to point PinePods at an external server, and describe the startup failure behind the reported 502.

Related to #975. This addresses its documentation request; the health endpoint's behavior is unchanged, so the issue can remain open for that discussion.

Checked the startup sequence, configuration variables, and nginx routing against the source. `git diff --check` passes. Documentation only; no runtime tests were run.

Prepared with Codex assistance.
